### PR TITLE
readme: mermaid sequence diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@
 
 A middleware server written in Go, that sits between an ethereum PoS consensus client and an execution client. It allows consensus clients to outsource block construction to third party block builders as well as fallback to execution clients. See [ethresearch post](https://ethresear.ch/t/mev-boost-merge-ready-flashbots-architecture/11177/) for the high level architecture.
 
-![block-proposal](/docs/block-proposal.png)
+```mermaid
+sequenceDiagram
+    Title: Block Proposal
+    consensus->>mev_boost: engine_forkchoiceUpdatedV1
+    mev_boost->>relays: engine_forkchoiceUpdatedV1
+    Note over consensus: wait for allocated slot
+    consensus->>mev_boost: builder_getPayloadHeaderV1
+    mev_boost->>relays: relay_getPayloadHeaderV1
+    Note over mev_boost: select most valuable payload
+    mev_boost-->>consensus: builder_getPayloadHeaderV1 response
+    Note over consensus: sign the block
+    consensus->>mev_boost: builder_proposeBlindedBlockV1
+    Note over mev_boost: identify payload source
+    mev_boost->>relays: relay_proposeBlindedBlockV1
+    Note over relays: validate signature
+    relays-->>mev_boost: relay_proposeBlindedBlockV1 response
+    mev_boost-->>consensus: builder_proposeBlindedBlockV1 response
+```
 
 ## Table of Contents
 - [mev-boost](#mev-boost)


### PR DESCRIPTION
Removes EL client, otherwise same flow as `docs/block-proposal.png`. Should probably replace `docs/block-proposal.png` at some point.