### PR TITLE
store: periodic cleanup

### DIFF
--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -37,7 +37,7 @@ func main() {
 		_relayURLs = append(_relayURLs, strings.Trim(entry, " "))
 	}
 
-	store := lib.NewStore()
+	store := lib.NewStore(true)
 	router, err := lib.NewRouter(_relayURLs, store, log)
 	if err != nil {
 		panic(err)

--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -37,7 +37,7 @@ func main() {
 		_relayURLs = append(_relayURLs, strings.Trim(entry, " "))
 	}
 
-	store := lib.NewStore(true)
+	store := lib.NewStoreWithCleanup()
 	router, err := lib.NewRouter(_relayURLs, store, log)
 	if err != nil {
 		panic(err)

--- a/lib/router_test.go
+++ b/lib/router_test.go
@@ -83,7 +83,7 @@ func TestNewRouter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewRouter(tt.relayURLs, NewStore(), logrus.WithField("testing", true))
+			_, err := NewRouter(tt.relayURLs, NewStore(false), logrus.WithField("testing", true))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRouter() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -157,7 +157,7 @@ func testHTTPMethodWithDifferentRPC(t *testing.T, jsonRPCMethodCaller string, js
 		mockRelay, mockRelayHTTP := newMockHTTPServer(t, tt.mockStatusCode, string(bodyRelayProxy), string(resp), tt.errorRelay)
 
 		if store == nil {
-			store = NewStore()
+			store = NewStore(false)
 			store.SetForkchoiceResponse("0x01", mockRelayHTTP.URL, "0x01")
 		}
 
@@ -275,7 +275,7 @@ func TestRelayService_GetPayloadHeaderV1(t *testing.T) {
 }
 
 func TestRelayService_GetPayloadAndPropose(t *testing.T) {
-	store := NewStore()
+	store := NewStore(false)
 
 	payload := ExecutionPayloadWithTxRootV1{
 		BlockHash:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
@@ -334,7 +334,7 @@ func TestRelayService_GetPayloadAndPropose(t *testing.T) {
 }
 
 func TestRelayService_GetPayloadAndProposeCamelCase(t *testing.T) {
-	store := NewStore()
+	store := NewStore(false)
 
 	payload := ExecutionPayloadWithTxRootV1{
 		BlockHash:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),

--- a/lib/router_test.go
+++ b/lib/router_test.go
@@ -83,7 +83,7 @@ func TestNewRouter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewRouter(tt.relayURLs, NewStore(false), logrus.WithField("testing", true))
+			_, err := NewRouter(tt.relayURLs, NewStore(), logrus.WithField("testing", true))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRouter() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -157,7 +157,7 @@ func testHTTPMethodWithDifferentRPC(t *testing.T, jsonRPCMethodCaller string, js
 		mockRelay, mockRelayHTTP := newMockHTTPServer(t, tt.mockStatusCode, string(bodyRelayProxy), string(resp), tt.errorRelay)
 
 		if store == nil {
-			store = NewStore(false)
+			store = NewStore()
 			store.SetForkchoiceResponse("0x01", mockRelayHTTP.URL, "0x01")
 		}
 
@@ -275,7 +275,7 @@ func TestRelayService_GetPayloadHeaderV1(t *testing.T) {
 }
 
 func TestRelayService_GetPayloadAndPropose(t *testing.T) {
-	store := NewStore(false)
+	store := NewStore()
 
 	payload := ExecutionPayloadWithTxRootV1{
 		BlockHash:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
@@ -334,7 +334,7 @@ func TestRelayService_GetPayloadAndPropose(t *testing.T) {
 }
 
 func TestRelayService_GetPayloadAndProposeCamelCase(t *testing.T) {
-	store := NewStore(false)
+	store := NewStore()
 
 	payload := ExecutionPayloadWithTxRootV1{
 		BlockHash:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),

--- a/lib/store.go
+++ b/lib/store.go
@@ -2,9 +2,32 @@ package lib
 
 import (
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 )
+
+var (
+	cleanupLoopInterval = 5 * time.Minute
+	stateExpiry         = 7 * time.Minute // a bit more than an epoch with 6.4 min
+)
+
+type executionPayloadContainer struct {
+	Payload *ExecutionPayloadWithTxRootV1
+	AddedAt time.Time
+}
+
+type forkchoiceResponseContainer struct {
+	Payload map[string]string // map[relayURL]relayPayloadID
+	AddedAt time.Time
+}
+
+func newForkchoiceResponseContainer() forkchoiceResponseContainer {
+	return forkchoiceResponseContainer{
+		Payload: make(map[string]string),
+		AddedAt: time.Now(),
+	}
+}
 
 // Store stores payloads and retrieves them based on blockHash hashes
 type Store interface {
@@ -13,6 +36,8 @@ type Store interface {
 
 	SetForkchoiceResponse(boostPayloadID, relayURL, relayPayloadID string)
 	GetForkchoiceResponse(boostPayloadID string) (map[string]string, bool)
+
+	Cleanup()
 }
 
 // map[common.Hash]*ExecutionPayloadWithTxRootV1
@@ -20,19 +45,30 @@ type Store interface {
 // TODO: clean this up periodically
 
 type store struct {
-	payloads     map[common.Hash]*ExecutionPayloadWithTxRootV1
+	payloads     map[common.Hash]executionPayloadContainer
 	payloadMutex sync.RWMutex
 
-	forkchoices     map[string]map[string]string // map[boostPayloadID]map[relayURL]relayPayloadID
+	forkchoices     map[string]forkchoiceResponseContainer // key=boostPayloadID
 	forkchoiceMutex sync.RWMutex
 }
 
-// NewStore creates an in-mem store
-func NewStore() Store {
-	return &store{
-		payloads:    map[common.Hash]*ExecutionPayloadWithTxRootV1{},
-		forkchoices: make(map[string]map[string]string),
+// NewStore creates an in-mem store. If startCleanupLoop is true, a goroutine is started that periodically removes old entries.
+func NewStore(startCleanupLoop bool) Store {
+	s := &store{
+		payloads:    make(map[common.Hash]executionPayloadContainer),
+		forkchoices: make(map[string]forkchoiceResponseContainer),
 	}
+
+	if startCleanupLoop {
+		go func() {
+			for {
+				time.Sleep(cleanupLoopInterval)
+				s.Cleanup()
+			}
+		}()
+	}
+
+	return s
 }
 
 func (s *store) GetExecutionPayload(blockHash common.Hash) *ExecutionPayloadWithTxRootV1 {
@@ -44,7 +80,7 @@ func (s *store) GetExecutionPayload(blockHash common.Hash) *ExecutionPayloadWith
 		return nil
 	}
 
-	return payload
+	return payload.Payload
 }
 
 func (s *store) SetExecutionPayload(blockHash common.Hash, payload *ExecutionPayloadWithTxRootV1) {
@@ -55,21 +91,42 @@ func (s *store) SetExecutionPayload(blockHash common.Hash, payload *ExecutionPay
 	s.payloadMutex.Lock()
 	defer s.payloadMutex.Unlock()
 
-	s.payloads[blockHash] = payload
+	s.payloads[blockHash] = executionPayloadContainer{payload, time.Now()}
 }
 
 func (s *store) GetForkchoiceResponse(payloadID string) (map[string]string, bool) {
 	s.forkchoiceMutex.RLock()
 	defer s.forkchoiceMutex.RUnlock()
 	forkchoiceResponses, found := s.forkchoices[payloadID]
-	return forkchoiceResponses, found
+	return forkchoiceResponses.Payload, found
 }
 
 func (s *store) SetForkchoiceResponse(boostPayloadID, relayURL, relayPayloadID string) {
 	s.forkchoiceMutex.Lock()
 	defer s.forkchoiceMutex.Unlock()
 	if _, ok := s.forkchoices[boostPayloadID]; !ok {
-		s.forkchoices[boostPayloadID] = make(map[string]string)
+		s.forkchoices[boostPayloadID] = newForkchoiceResponseContainer()
 	}
-	s.forkchoices[boostPayloadID][relayURL] = relayPayloadID
+	s.forkchoices[boostPayloadID].Payload[relayURL] = relayPayloadID
+}
+
+// Cleanup removes all payloads older than 7 minutes (a bit more than an epoch, which is 6.4 minutes)
+func (s *store) Cleanup() {
+	// Cleanup ExecutionPayload
+	s.payloadMutex.Lock()
+	for entry := range s.payloads {
+		if time.Since(s.payloads[entry].AddedAt) > stateExpiry {
+			delete(s.payloads, entry)
+		}
+	}
+	s.payloadMutex.Unlock()
+
+	// Cleanup ForkchoiceResponse
+	s.forkchoiceMutex.Lock()
+	for entry := range s.forkchoices {
+		if time.Since(s.forkchoices[entry].AddedAt) > stateExpiry {
+			delete(s.forkchoices, entry)
+		}
+	}
+	s.forkchoiceMutex.Unlock()
 }

--- a/lib/store_test.go
+++ b/lib/store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_store_SetGetExecutionPayload(t *testing.T) {
-	s := NewStore()
+	s := NewStore(false)
 	h := common.HexToHash("0x1")
 	payload := s.GetExecutionPayload(h)
 	if payload != nil {
@@ -30,7 +30,7 @@ func Test_store_SetGetExecutionPayload(t *testing.T) {
 }
 
 func Test_store_SetGetGetForkchoiceResponse(t *testing.T) {
-	s := NewStore()
+	s := NewStore(false)
 	id := "0x1"
 	_, ok := s.GetForkchoiceResponse(id)
 	require.Equal(t, false, ok)

--- a/lib/store_test.go
+++ b/lib/store_test.go
@@ -3,13 +3,14 @@ package lib
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_store_SetGetExecutionPayload(t *testing.T) {
-	s := NewStore(false)
+	s := NewStore()
 	h := common.HexToHash("0x1")
 	payload := s.GetExecutionPayload(h)
 	if payload != nil {
@@ -30,7 +31,7 @@ func Test_store_SetGetExecutionPayload(t *testing.T) {
 }
 
 func Test_store_SetGetGetForkchoiceResponse(t *testing.T) {
-	s := NewStore(false)
+	s := NewStore()
 	id := "0x1"
 	_, ok := s.GetForkchoiceResponse(id)
 	require.Equal(t, false, ok)
@@ -52,4 +53,35 @@ func Test_store_SetGetGetForkchoiceResponse(t *testing.T) {
 	res, ok = s.GetForkchoiceResponse(id)
 	require.Equal(t, true, ok)
 	require.Equal(t, res[relayURL], relayPayloadID)
+}
+
+func Test_store_Cleanup(t *testing.T) {
+	// Reset 'now' after this test
+	defer func() { now = time.Now }()
+
+	s := NewStoreWithCleanup()
+	id1 := "123"
+	id2 := "234"
+
+	// Add a store item 20 minutes in the past
+	now = func() time.Time { return time.Now().Add(-20 * time.Minute) }
+	s.SetForkchoiceResponse(id1, "abc", "0x2")
+
+	// Add a store item 5 minutes in the past
+	now = func() time.Time { return time.Now().Add(-5 * time.Minute) }
+	s.SetForkchoiceResponse(id2, "abc", "0x2")
+
+	_, ok := s.GetForkchoiceResponse(id1)
+	require.Equal(t, true, ok)
+	_, ok = s.GetForkchoiceResponse(id2)
+	require.Equal(t, true, ok)
+
+	// Cleanup should remove 1 item, because it was added long enough in the past
+	s.Cleanup()
+
+	// Test for items
+	_, ok = s.GetForkchoiceResponse(id1)
+	require.Equal(t, false, ok)
+	_, ok = s.GetForkchoiceResponse(id2)
+	require.Equal(t, true, ok)
 }


### PR DESCRIPTION
Not sure where to kickoff the loop that executes the periodic cleanup. Right now I've added it to `NewStore`:

```go
func NewStore(startCleanupLoop bool) Store {
```

Would love to hear thoughts/feedback on what's the best place and way to do this.

Store entries are kept around for a minimum of 7 minutes, just a bit more than an epoch with 6.4 min.

Closes #54 