### PR TITLE
spec: SSZ cleanup

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -56,22 +56,6 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 
 Consider the following definitions supplementary to the definitions in [`consensus-specs`][consensus-specs].
 
-##### `builder_setFeeRecipientV1` Request
-
-```python
-class Request(Container):
-    feeRecipient: Bytes20
-    timestamp: uint64
-```
-
-##### `builder_getPayloadV1` Response
-
-```python
-class Response(Container):
-    payload: ExecutionPayloadHeader
-    value: uint256
-```
-
 ##### `builder_getPayloadV1` Request
 
 ###### `BlindBeaconBlock`


### PR DESCRIPTION
A proposal to clean up the SSZ confusion: use SSZ encoding for block/header data structures, but not for other JSON-RPC params (eg. `setFeeRecipient` params, or the `value` of field of the `getHeader` response).

I wonder if `ExecutionPayloadHeaderV1` and `ExecutionPayloadV1` in the responses shouldn't also be SSZ encoded?

See also #76 

Ping @lightclient @tersec @terencechain 