### PR TITLE
A few updates to the spec

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,4 +1,4 @@
-# Version 0.3
+# Version 0.2.1
 
 This document specifies the Builder API methods that the Consensus Layer uses to interact with external block builders.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,4 +1,4 @@
-# Version 0.2
+# Version 0.3
 
 This document specifies the Builder API methods that the Consensus Layer uses to interact with external block builders.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -161,7 +161,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 #### Specification
 1. Builder software **MUST** verify `signature` is valid under `publicKey`.
-2. Builder software **MUST** respond to requests where `timestamp` is before the latest announcement from the validator or more than +/- 10 seconds from the current time with `-32006: Invalid timestamp`.
+2. Builder software **MUST** respond to requests where `timestamp` is before the latest announcement from the validator with `-32006: Invalid timestamp`.
 3. Builder software **MUST** store `feeRecipient` in a map keyed by `publicKey`.
 
 ### `builder_getHeaderV1`


### PR DESCRIPTION
@mcdee shared some [good feedback](https://discord.com/channels/595666850260713488/874767108809031740/964048921049563176) on discord, so the following was updated:
* Renamed the SSZ containers to be more descriptive.
* Added `SignedBlindBeaconBlock` container.
* Encapsulated "messages" and "signatures" in the spec by creating objects out of what will be mapped into an SSZ for signing.
* Specified that `hash` in `GetHeader` refers to an execution layer block hash.
* Noted that the `feeRecipient` field of the header **MAY** deviate from the validator's mapped `feeRecipient` so long as there is a payment in the block to the expected `feeRecipient`.
* Removed a comment about malleability between the builder provided header and the signed blind beacon block from the validator.

Will open a separate PR to discuss removing `SetFeeRecipient`.