### PR TITLE
Minor cleanups: return err, unused args...

### DIFF
--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	listenAddress := fmt.Sprintf("%s:%d", *host, *port)
-	server, err := server.NewBoostRPCServer(server.BoostRPCServerOptions{
+	s, err := server.NewBoostRPCServer(server.BoostRPCServerOptions{
 		ListenAddr:       listenAddress,
 		RelayURLs:        _relayURLs,
 		Cors:             []string{"*"},
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	log.Println("listening on ", listenAddress)
-	log.Fatal(server.ListenAndServe())
+	log.Fatal(s.ListenAndServe())
 }
 
 func getEnv(key string, defaultValue string) string {

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -28,7 +28,7 @@ func newTestBoostRPCServerWithTimeout(relayURLs []string, getHeaderTimeout time.
 		return nil, err
 	}
 
-	srv, err := NewRPCServer("builder", boost, true)
+	srv, err := NewRPCServer("builder", boost)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpcserver.go
+++ b/server/rpcserver.go
@@ -39,7 +39,7 @@ func NewBoostRPCServer(opts BoostRPCServerOptions) (*http.Server, error) {
 		return nil, err
 	}
 
-	srv, err := NewRPCServer("builder", boost, true)
+	srv, err := NewRPCServer("builder", boost)
 	if err != nil {
 		return nil, err
 	}
@@ -47,9 +47,11 @@ func NewBoostRPCServer(opts BoostRPCServerOptions) (*http.Server, error) {
 }
 
 // NewRPCServer creates a new RPC server
-func NewRPCServer(namespace string, backend interface{}, authenticated bool) (*gethRpc.Server, error) {
+func NewRPCServer(namespace string, backend interface{}) (*gethRpc.Server, error) {
 	srv := gethRpc.NewServer()
-	srv.RegisterName(namespace, backend)
+	if err := srv.RegisterName(namespace, backend); err != nil {
+		return nil, fmt.Errorf("could not create service: %w", err)
+	}
 	apis := []gethRpc.API{
 		{
 			Namespace: namespace,

--- a/server/service.go
+++ b/server/service.go
@@ -321,6 +321,6 @@ func (m *BoostService) GetPayloadV1(ctx context.Context, block types.BlindedBeac
 }
 
 // Status implements the builder_status RPC method
-func (m *BoostService) Status(ctx context.Context) (*string, error) {
+func (m *BoostService) Status(context.Context) (*string, error) {
 	return &ServiceStatusOk, nil
 }


### PR DESCRIPTION
Fixed some code warnings
 - rename `server` to `s` to not be the same as the import
 - remove unused arguments
 - return error for `RegisterName`