### PR TITLE
test_cli: flow sanity check cli for mev-boost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ v:
 build:
 	go build ./cmd/mev-boost
 
+build-cli:
+	go build ./cmd/test-cli
+
 test:
 	go test ./...
 

--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ to run mergemock in dev mode:
 ```
 make MERGEMOCK_BIN='go run .' run-mergemock-integration
 ```
+
+## Testing with test-cli
+
+[test-cli readme](cmd/test-cli/README.md)

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -11,15 +11,15 @@ make build-cli
 ```
 ./test-cli [generate|register|getHeader|getPayload] [-help]
 
-generate [-vd-file] [-coinbase]
+generate [-vd-file] [-fee-recipient]
 register [-vd-file] [-mev-boost]
 getHeader [-vd-file] [-mev-boost] [-bn] [-en] [-mm]
 getPayload [-vd-file] [-mev-boost] [-bn] [-en] [-mm]
 
 Env & defaults:
 	[generate]
-	-gas-limit                     = 1000
-	-coinbase  VALIDATOR_COINBASE  = 0x0000000000000000000000000000000000000000
+	-gas-limit                               = 30000000
+	-fee-recipient  VALIDATOR_FEE_RECIPIENT  = 0x0000000000000000000000000000000000000000
 
 	[register]
 	-vd-file   VALIDATOR_DATA_FILE = ./validator_data.json
@@ -41,7 +41,7 @@ Env & defaults:
 ## Run mev-boost
 
 ```
-./mev-boost -relayUrl http://builder-relay-kiln.flashbots.net
+./mev-boost -relays https://builder-relay-kiln.flashbots.net
 ```
 
 ## Run beacon node
@@ -57,7 +57,7 @@ If running against mergemock, `test-cli` will take the block hash from execution
 ## Generate validator data
 
 ```
-./test-cli generate [-gas-limit GAS_LIMIT] [-coinbase COINBASE]
+./test-cli generate [-gas-limit GAS_LIMIT] [-fee-recipient FEE_RECIPIENT]
 ```
 
 If you wish you can substitute the randomly generated validator data in the validator data file.

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -1,0 +1,86 @@
+# test-cli
+
+## Build
+
+```
+make build-cli
+```
+
+## Usage
+
+```
+./test-cli [generate|register|getHeader|getPayload] [-help]
+
+generate [-vd-file] [-coinbase]
+register [-vd-file] [-mev-boost]
+getHeader [-vd-file] [-mev-boost] [-bn] [-en] [-mm]
+getPayload [-vd-file] [-mev-boost] [-bn] [-en] [-mm]
+
+Env & defaults:
+	[generate]
+	-gas-limit                     = 1000
+	-coinbase  VALIDATOR_COINBASE  = 0x0000000000000000000000000000000000000000
+
+	[register]
+	-vd-file   VALIDATOR_DATA_FILE = ./validator_data.json
+	-mev-boost MEV_BOOST_ENDPOINT  = http://127.0.0.1:18550
+
+	[getHeader|getPayload]
+	-vd-file   VALIDATOR_DATA_FILE = ./validator_data.json
+	-mev-boost MEV_BOOST_ENDPOINT  = http://127.0.0.1:18550
+	-bn        BEACON_ENDPOINT     = http://localhost:5052
+	-en        ENGINE_ENDPOINT     = http://localhost:8545  - only used if -mm is passed or pre-bellatrix
+	-mm                                                     - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
+
+	           GENESIS_VALIDATORS_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000" - per network genesis validators root
+	                                     "0x99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad"   for kiln
+
+	           FORK_VERSION            = "0x02000000" (Bellatrix) - per network fork version
+```
+
+## Run mev-boost
+
+```
+./mev-boost -relayUrl http://builder-relay-kiln.flashbots.net
+```
+
+## Run beacon node
+
+`test-cli` needs beacon node to know current block hash (getHeader) and slot (getPayload).
+If running against mergemock, pass `-mm` and disregard `-bn`.
+
+## Pre-bellatrix run execution layer
+
+Beacon node does not reply with block hash, it has to be taken from the execution.
+If running against mergemock, `test-cli` will take the block hash from execution and fake the slot.
+
+## Generate validator data
+
+```
+./test-cli generate [-gas-limit GAS_LIMIT] [-coinbase COINBASE]
+```
+
+If you wish you can substitute the randomly generated validator data in the validator data file.
+
+## Register the validator
+
+```
+./test-cli register [-mev-boost]
+```
+
+## Test getHeader
+
+```
+./test-cli getHeader [-mev-boost] [-bn beacon_endpoint] [-en execution_endpoint] [-mm]
+```
+
+The call will return relay's current header.
+
+## Test getPayload
+
+```
+./test-cli getPayload [-mev-boost] [-bn beacon_endpoint] [-en execution_endpoint] [-mm]
+```
+
+The call will return relay's best execution payload.
+Signature checks on the test relay are disabled to allow ad-hoc testing.

--- a/cmd/test-cli/engine.go
+++ b/cmd/test-cli/engine.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type engineBlockData struct {
+	ParentHash common.Hash    `json:"parentHash"`
+	Hash       common.Hash    `json:"hash"`
+	Timestamp  hexutil.Uint64 `json:"timestamp"`
+}
+
+func getLatestEngineBlock(engineEndpoint string) (engineBlockData, error) {
+	dst := engineBlockData{}
+	payload := map[string]any{"id": 67, "jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": []any{"latest", false}}
+	err := sendJSONRequest(engineEndpoint, payload, &dst)
+	if err != nil {
+		log.WithError(err).Info("could not get latest block")
+		return engineBlockData{}, err
+	}
+
+	return dst, nil
+}
+
+type forkchoiceState struct {
+	HeadBlockHash      common.Hash `json:"headBlockHash"`
+	SafeBlockHash      common.Hash `json:"safeBlockHash"`
+	FinalizedBlockHash common.Hash `json:"finalizedBlockHash"`
+}
+
+type payloadAttributes struct {
+	Timestamp             hexutil.Uint64 `json:"timestamp"`
+	PrevRandao            common.Hash    `json:"prevRandao"`
+	SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient"`
+}
+
+func sendForkchoiceUpdate(engineEndpoint string, block engineBlockData) error {
+	log.WithField("hash", block.Hash).Info("sending FCU")
+	params := []any{
+		forkchoiceState{block.Hash, block.Hash, block.Hash},
+		payloadAttributes{hexutil.Uint64(block.Timestamp + 1), common.Hash{0x01}, common.Address{0x02}},
+	}
+	payload := map[string]any{"id": 67, "jsonrpc": "2.0", "method": "engine_forkchoiceUpdatedV1", "params": params}
+	return sendJSONRequest(engineEndpoint, payload, nil)
+}

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.WithField("service", "cmd/test-cli")
+
+func doGenerateValidator(filePath string, gasLimit uint64, coinbase string) {
+	v := newRandomValidator(gasLimit, coinbase)
+	err := v.SaveValidator(filePath)
+	if err != nil {
+		log.WithField("err", err).Fatal("Could not save validator data")
+	}
+	log.WithField("file", filePath).Info("Saved validator data")
+}
+
+func doRegisterValidator(v validatorPrivateData, boostEndpoint string) {
+	message, err := v.PrepareRegistrationMessage()
+	if err != nil {
+		log.WithField("err", err).Fatal("Could not prepare registration message")
+	}
+	err = sendRESTRequest(boostEndpoint+"/eth/v1/builder/validators", "POST", []any{message}, nil)
+
+	if err != nil {
+		log.WithField("err", err).Fatal("Validator registration not successful")
+	}
+
+	log.WithError(err).Info("Registered validator")
+}
+
+func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string) boostTypes.GetHeaderResponse {
+	// Mergemock needs to call forkchoice update before getHeader, for non-mergemock beacon node this is a no-op
+	err := beaconNode.onGetHeader()
+	if err != nil {
+		log.WithError(err).Fatal("onGetHeader hook failed")
+	}
+
+	currentBlock, err := beaconNode.getCurrentBeaconBlock()
+	if err != nil {
+		log.WithError(err).Fatal("could not retrieve current block hash from beacon endpoint")
+	}
+
+	var currentBlockHash string
+	var emptyHash common.Hash
+	// Beacon does not return block hash pre-bellatrix, fetch it from the engine if that's the case
+	if currentBlock.BlockHash != emptyHash {
+		currentBlockHash = currentBlock.BlockHash.String()
+	} else if currentBlockHash == "" {
+		block, err := getLatestEngineBlock(engineEndpoint)
+		if err != nil {
+			log.WithError(err).Fatal("could not get current block hash")
+		}
+		currentBlockHash = block.Hash.String()
+	}
+
+	uri := fmt.Sprintf("%s/eth/v1/builder/header/%d/%s/%s", boostEndpoint, currentBlock.Slot+1, currentBlockHash, v.Pk.String())
+
+	var getHeaderResp boostTypes.GetHeaderResponse
+	if err := sendRESTRequest(uri, "GET", nil, &getHeaderResp); err != nil {
+		log.WithField("err", err).WithField("currentBlockHash", currentBlockHash).Fatal("Could not get header")
+	}
+
+	log.WithField("header", getHeaderResp).Info("Got header from boost")
+	return getHeaderResp
+}
+
+func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, signingDomain boostTypes.Domain) {
+	header := doGetHeader(v, boostEndpoint, beaconNode, engineEndpoint)
+
+	blindedBeaconBlock := boostTypes.BlindedBeaconBlock{
+		Slot:          0,
+		ProposerIndex: 0,
+		ParentRoot:    boostTypes.Root{},
+		StateRoot:     boostTypes.Root{},
+		Body: &boostTypes.BlindedBeaconBlockBody{
+			RandaoReveal:           boostTypes.Signature{},
+			Eth1Data:               &boostTypes.Eth1Data{},
+			Graffiti:               boostTypes.Hash{},
+			ProposerSlashings:      []*boostTypes.ProposerSlashing{},
+			AttesterSlashings:      []*boostTypes.AttesterSlashing{},
+			Attestations:           []*boostTypes.Attestation{},
+			Deposits:               []*boostTypes.Deposit{},
+			VoluntaryExits:         []*boostTypes.VoluntaryExit{},
+			SyncAggregate:          &boostTypes.SyncAggregate{},
+			ExecutionPayloadHeader: header.Data.Message.Header,
+		},
+	}
+
+	signature, err := v.Sign(&blindedBeaconBlock, signingDomain)
+	log.WithField("msg", blindedBeaconBlock.Body).WithField("sd", signingDomain).WithField("sig", signature).Info("sign getPayload")
+	if err != nil {
+		log.WithError(err).Fatal("could not sign blinded beacon block")
+	}
+
+	payload := boostTypes.SignedBlindedBeaconBlock{
+		Message:   &blindedBeaconBlock,
+		Signature: signature,
+	}
+	var respPayload boostTypes.GetPayloadResponse
+	if err := sendRESTRequest(boostEndpoint+"/eth/v1/builder/blinded_blocks", "POST", payload, &respPayload); err != nil {
+		log.WithError(err).Fatal("could not get payload")
+	}
+
+	log.WithField("payload", respPayload).Info("got payload from mev-boost")
+}
+
+func main() {
+	generateCommand := flag.NewFlagSet("generate", flag.ExitOnError)
+	registerCommand := flag.NewFlagSet("register", flag.ExitOnError)
+	getHeaderCommand := flag.NewFlagSet("getHeader", flag.ExitOnError)
+	getPayloadCommand := flag.NewFlagSet("getPayload", flag.ExitOnError)
+
+	var validatorDataFile string
+	envValidatorDataFile := getEnv("VALIDATOR_DATA_FILE", "./validator_data.json")
+	generateCommand.StringVar(&validatorDataFile, "vd-file", envValidatorDataFile, "Path to validator data file")
+	registerCommand.StringVar(&validatorDataFile, "vd-file", envValidatorDataFile, "Path to validator data file")
+	getHeaderCommand.StringVar(&validatorDataFile, "vd-file", envValidatorDataFile, "Path to validator data file")
+	getPayloadCommand.StringVar(&validatorDataFile, "vd-file", envValidatorDataFile, "Path to validator data file")
+
+	var boostEndpoint string
+	envBoostEndpoint := getEnv("MEV_BOOST_ENDPOINT", "http://127.0.0.1:18550")
+	registerCommand.StringVar(&boostEndpoint, "mev-boost", envBoostEndpoint, "Mev boost endpoint")
+	getHeaderCommand.StringVar(&boostEndpoint, "mev-boost", envBoostEndpoint, "Mev boost endpoint")
+	getPayloadCommand.StringVar(&boostEndpoint, "mev-boost", envBoostEndpoint, "Mev boost endpoint")
+
+	var beaconEndpoint string
+	envBeaconEndpoint := getEnv("BEACON_ENDPOINT", "http://localhost:5052")
+	getHeaderCommand.StringVar(&beaconEndpoint, "bn", envBeaconEndpoint, "Beacon node endpoint")
+	getPayloadCommand.StringVar(&beaconEndpoint, "bn", envBeaconEndpoint, "Beacon node endpoint")
+
+	var isMergemock bool
+	getHeaderCommand.BoolVar(&isMergemock, "mm", false, "Use mergemock EL to fake beacon node")
+	getPayloadCommand.BoolVar(&isMergemock, "mm", false, "Use mergemock EL to fake beacon node")
+
+	var engineEndpoint string
+	envEngineEndpoint := getEnv("ENGINE_ENDPOINT", "http://localhost:8545")
+	getHeaderCommand.StringVar(&engineEndpoint, "en", envEngineEndpoint, "Engine endpoint")
+	getPayloadCommand.StringVar(&engineEndpoint, "en", envEngineEndpoint, "Engine endpoint")
+
+	var genesisValidatorsRootStr string
+	envGenesisValidatorsRoot := getEnv("GENESIS_VALIDATORS_ROOT", "0x0000000000000000000000000000000000000000000000000000000000000000")
+	getPayloadCommand.StringVar(&genesisValidatorsRootStr, "genesis-validators-root", envGenesisValidatorsRoot, "Root of genesis validators")
+
+	var forkVersionStr string
+	envForkVersion := getEnv("FORK_VERSION", "0x02000000")
+	getPayloadCommand.StringVar(&forkVersionStr, "fork-version", envForkVersion, "hex encoded fork version")
+
+	var gasLimit uint64
+	envGasLimitStr := getEnv("VALIDATOR_GAS_LIMIT", "30000000")
+	envGasLimit, err := strconv.Atoi(envGasLimitStr)
+	if err != nil {
+		log.WithError(err).Fatal("invalid gas limit specified")
+	}
+	generateCommand.Uint64Var(&gasLimit, "gas-limit", uint64(envGasLimit), "Gas limit to register the validator with")
+
+	var validatorCoinbase string
+	envValidatorCoinbase := getEnv("VALIDATOR_COINBASE", "0x0000000000000000000000000000000000000000")
+	generateCommand.StringVar(&validatorCoinbase, "coinbase", envValidatorCoinbase, "Coinbase to register the validator with")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s [generate|register|getHeader|getPayload]:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	if len(os.Args) < 2 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "generate":
+		generateCommand.Parse(os.Args[2:])
+		doGenerateValidator(validatorDataFile, gasLimit, validatorCoinbase)
+	case "register":
+		registerCommand.Parse(os.Args[2:])
+		doRegisterValidator(mustLoadValidator(validatorDataFile), boostEndpoint)
+	case "getHeader":
+		getHeaderCommand.Parse(os.Args[2:])
+		doGetHeader(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint)
+	case "getPayload":
+		getPayloadCommand.Parse(os.Args[2:])
+		genesisValidatorsRoot := boostTypes.Root(common.HexToHash(genesisValidatorsRootStr))
+		forkVersionBytes, err := hexutil.Decode(forkVersionStr)
+		if err != nil || len(forkVersionBytes) > 4 {
+			fmt.Println("Invalid fork version passed")
+			os.Exit(1)
+		}
+		var forkVersion [4]byte
+		copy(forkVersion[:], forkVersionBytes[:4])
+		signingDomain := boostTypes.ComputeDomain(boostTypes.DomainTypeBeaconProposer, forkVersion, genesisValidatorsRoot)
+		doGetPayload(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint, signingDomain)
+	default:
+		fmt.Println("Expected generate|register|getHeader|getPayload subcommand")
+		os.Exit(1)
+	}
+}
+
+func getEnv(key string, defaultValue string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return defaultValue
+}

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -28,7 +28,7 @@ func doRegisterValidator(v validatorPrivateData, boostEndpoint string) {
 	if err != nil {
 		log.WithError(err).Fatal("Could not prepare registration message")
 	}
-	err = sendRESTRequest(boostEndpoint+"/eth/v1/builder/validators", "POST", []any{message}, nil)
+	err = sendRESTRequest(boostEndpoint+"/eth/v1/builder/validators", "POST", message, nil)
 
 	if err != nil {
 		log.WithError(err).Fatal("Validator registration not successful")

--- a/cmd/test-cli/requests.go
+++ b/cmd/test-cli/requests.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+func sendRESTRequest(url string, method string, payload any, dst any) error {
+	fetchLog := log.WithField("url", url)
+	var req *http.Request
+	if payload == nil {
+		var err error
+		req, err = http.NewRequest(method, url, nil)
+		if err != nil {
+			fetchLog.WithField("err", err).Error("invalid request")
+			return err
+		}
+	} else {
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		req, err = http.NewRequest(method, url, bytes.NewReader(payloadBytes))
+		if err != nil {
+			fetchLog.WithField("err", err).Error("invalid request")
+			return err
+		}
+	}
+
+	req.Header.Set("accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fetchLog.WithField("err", err).Error("client refused")
+		return err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fetchLog.WithField("err", err).Error("could not read response body")
+		return err
+	}
+
+	fetchLog = fetchLog.WithField("body", string(bodyBytes))
+
+	if resp.StatusCode >= 300 {
+		ec := &struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}{}
+		if err = json.Unmarshal(bodyBytes, ec); err != nil {
+			fetchLog.WithField("err", err).Error("Couldn't unmarshal error from beacon node")
+			return errors.New("could not unmarshal error response from beacon node")
+		}
+		return errors.New(ec.Message)
+	}
+
+	if dst != nil {
+		err = json.Unmarshal(bodyBytes, dst)
+		if err != nil {
+			fetchLog.WithField("err", err).Error("could not unmarshal response")
+			return err
+		}
+
+		fetchLog.WithField("res", dst).Info("fetched")
+	} else {
+		fetchLog.Info("fetched")
+	}
+	return nil
+}
+
+type jsonrpcMessage struct {
+	Version string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Error   *struct {
+		Code    int         `json:"code"`
+		Message string      `json:"message"`
+		Data    interface{} `json:"data,omitempty"`
+	} `json:"error,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+}
+
+func sendJSONRequest(endpoint string, payload any, dst any) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	body := bytes.NewReader(payloadBytes)
+	fetchLog := log.WithField("endpoint", endpoint).WithField("method", "POST").WithField("payload", string(payloadBytes))
+	fetchLog.Info("sending request")
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		fetchLog.WithField("err", err).Error("could not prepare request")
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fetchLog.WithField("err", err).Error("could not send request")
+		return err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	fetchLog.WithField("bodyBytes", string(bodyBytes)).Info("got response")
+	if err != nil {
+		return err
+	}
+
+	var jsonResp jsonrpcMessage
+	if err = json.Unmarshal(bodyBytes, &jsonResp); err != nil {
+		fetchLog.WithField("response", string(bodyBytes)).WithField("err", err).Error("could not unmarshal response")
+		return err
+	}
+
+	if jsonResp.Error != nil {
+		fetchLog.WithField("code", jsonResp.Error.Code).WithField("err", jsonResp.Error.Message).Error("error response")
+		return errors.New(jsonResp.Error.Message)
+	}
+
+	if dst != nil {
+		if err = json.Unmarshal(jsonResp.Result, dst); err != nil {
+			fetchLog.WithField("result", string(jsonResp.Result)).WithField("err", err).Error("could not unmarshal result")
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/test-cli/requests.go
+++ b/cmd/test-cli/requests.go
@@ -15,7 +15,7 @@ func sendRESTRequest(url string, method string, payload any, dst any) error {
 		var err error
 		req, err = http.NewRequest(method, url, nil)
 		if err != nil {
-			fetchLog.WithField("err", err).Error("invalid request")
+			fetchLog.WithError(err).Error("invalid request")
 			return err
 		}
 	} else {
@@ -25,7 +25,7 @@ func sendRESTRequest(url string, method string, payload any, dst any) error {
 		}
 		req, err = http.NewRequest(method, url, bytes.NewReader(payloadBytes))
 		if err != nil {
-			fetchLog.WithField("err", err).Error("invalid request")
+			fetchLog.WithError(err).Error("invalid request")
 			return err
 		}
 	}
@@ -34,14 +34,14 @@ func sendRESTRequest(url string, method string, payload any, dst any) error {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fetchLog.WithField("err", err).Error("client refused")
+		fetchLog.WithError(err).Error("client refused")
 		return err
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fetchLog.WithField("err", err).Error("could not read response body")
+		fetchLog.WithError(err).Error("could not read response body")
 		return err
 	}
 
@@ -53,7 +53,7 @@ func sendRESTRequest(url string, method string, payload any, dst any) error {
 			Message string `json:"message"`
 		}{}
 		if err = json.Unmarshal(bodyBytes, ec); err != nil {
-			fetchLog.WithField("err", err).Error("Couldn't unmarshal error from beacon node")
+			fetchLog.WithError(err).Error("Couldn't unmarshal error from beacon node")
 			return errors.New("could not unmarshal error response from beacon node")
 		}
 		return errors.New(ec.Message)
@@ -62,7 +62,7 @@ func sendRESTRequest(url string, method string, payload any, dst any) error {
 	if dst != nil {
 		err = json.Unmarshal(bodyBytes, dst)
 		if err != nil {
-			fetchLog.WithField("err", err).Error("could not unmarshal response")
+			fetchLog.WithError(err).Error("could not unmarshal response")
 			return err
 		}
 
@@ -97,14 +97,14 @@ func sendJSONRequest(endpoint string, payload any, dst any) error {
 	fetchLog.Info("sending request")
 	req, err := http.NewRequest("POST", endpoint, body)
 	if err != nil {
-		fetchLog.WithField("err", err).Error("could not prepare request")
+		fetchLog.WithError(err).Error("could not prepare request")
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fetchLog.WithField("err", err).Error("could not send request")
+		fetchLog.WithError(err).Error("could not send request")
 		return err
 	}
 	defer resp.Body.Close()
@@ -117,7 +117,7 @@ func sendJSONRequest(endpoint string, payload any, dst any) error {
 
 	var jsonResp jsonrpcMessage
 	if err = json.Unmarshal(bodyBytes, &jsonResp); err != nil {
-		fetchLog.WithField("response", string(bodyBytes)).WithField("err", err).Error("could not unmarshal response")
+		fetchLog.WithField("response", string(bodyBytes)).WithError(err).Error("could not unmarshal response")
 		return err
 	}
 
@@ -128,7 +128,7 @@ func sendJSONRequest(endpoint string, payload any, dst any) error {
 
 	if dst != nil {
 		if err = json.Unmarshal(jsonResp.Result, dst); err != nil {
-			fetchLog.WithField("result", string(jsonResp.Result)).WithField("err", err).Error("could not unmarshal result")
+			fetchLog.WithField("result", string(jsonResp.Result)).WithError(err).Error("could not unmarshal result")
 			return err
 		}
 	}

--- a/cmd/test-cli/validator.go
+++ b/cmd/test-cli/validator.go
@@ -28,12 +28,12 @@ func (v *validatorPrivateData) SaveValidator(filePath string) error {
 func mustLoadValidator(filePath string) validatorPrivateData {
 	fileData, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		log.WithField("filePath", filePath).WithField("err", err).Fatal("Could not load validator data")
+		log.WithField("filePath", filePath).WithError(err).Fatal("Could not load validator data")
 	}
 	var v validatorPrivateData
 	err = json.Unmarshal(fileData, &v)
 	if err != nil {
-		log.WithField("filePath", filePath).WithField("fileData", fileData).WithField("err", err).Fatal("Could not parse validator data")
+		log.WithField("filePath", filePath).WithField("fileData", fileData).WithError(err).Fatal("Could not parse validator data")
 	}
 	return v
 }

--- a/cmd/test-cli/validator.go
+++ b/cmd/test-cli/validator.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/flashbots/go-boost-utils/bls"
+	boostTypes "github.com/flashbots/go-boost-utils/types"
+)
+
+type validatorPrivateData struct {
+	Sk          hexutil.Bytes
+	Pk          hexutil.Bytes
+	GasLimit    hexutil.Uint64
+	CoinbaseHex string
+}
+
+func (v *validatorPrivateData) SaveValidator(filePath string) error {
+	validatorData, err := json.MarshalIndent(v, "", " ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filePath, validatorData, 0644)
+}
+
+func mustLoadValidator(filePath string) validatorPrivateData {
+	fileData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		log.WithField("filePath", filePath).WithField("err", err).Fatal("Could not load validator data")
+	}
+	var v validatorPrivateData
+	err = json.Unmarshal(fileData, &v)
+	if err != nil {
+		log.WithField("filePath", filePath).WithField("fileData", fileData).WithField("err", err).Fatal("Could not parse validator data")
+	}
+	return v
+}
+
+func newRandomValidator(gasLimit uint64, coinbase string) validatorPrivateData {
+	sk, pk, err := bls.GenerateNewKeypair()
+	if err != nil {
+		log.WithError(err).Fatal("unable to generate bls key pair")
+	}
+	return validatorPrivateData{sk.Serialize(), pk.Compress(), hexutil.Uint64(gasLimit), coinbase}
+}
+
+func (v *validatorPrivateData) PrepareRegistrationMessage() (boostTypes.SignedValidatorRegistration, error) {
+	pk := boostTypes.PublicKey{}
+	pk.FromSlice(v.Pk)
+	addr, err := boostTypes.HexToAddress(v.CoinbaseHex)
+	if err != nil {
+		return boostTypes.SignedValidatorRegistration{}, err
+	}
+	msg := boostTypes.RegisterValidatorRequestMessage{
+		FeeRecipient: addr,
+		Timestamp:    uint64(time.Now().UnixMilli()),
+		Pubkey:       pk,
+		GasLimit:     uint64(v.GasLimit),
+	}
+	signature, err := v.Sign(&msg, boostTypes.DomainBuilder)
+	log.WithField("msg", msg).WithField("domain", boostTypes.DomainBuilder).WithField("pk", pk).WithField("sig", signature).Info("register V")
+	if err != nil {
+		return boostTypes.SignedValidatorRegistration{}, err
+	}
+
+	return boostTypes.SignedValidatorRegistration{
+		Message:   &msg,
+		Signature: signature,
+	}, nil
+}
+
+func (v *validatorPrivateData) Sign(msg boostTypes.HashTreeRoot, domain boostTypes.Domain) (boostTypes.Signature, error) {
+	sk, err := bls.SecretKeyFromBytes(v.Sk)
+	if err != nil {
+		return boostTypes.Signature{}, err
+	}
+	return boostTypes.SignMessage(msg, domain, sk)
+}


### PR DESCRIPTION
Adds a command line tool to test relay endpoints. Usage in [test-cli readme](cmd/test-cli/README.md).

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
