### PR TITLE
Adjust signing domain computation in test-cli

### DIFF
--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -12,9 +12,9 @@ make build-cli
 ./test-cli [generate|register|getHeader|getPayload] [-help]
 
 generate [-vd-file] [-fee-recipient]
-register [-vd-file] [-mev-boost]
-getHeader [-vd-file] [-mev-boost] [-bn] [-en] [-mm]
-getPayload [-vd-file] [-mev-boost] [-bn] [-en] [-mm]
+register [-vd-file] [-mev-boost] [-genesis-fork-version] [-genesis-validators-root]
+getHeader [-vd-file] [-mev-boost] [-bn] [-en] [-mm] [-bellatrix-fork-version] [-genesis-validators-root]
+getPayload [-vd-file] [-mev-boost] [-bn] [-en] [-mm] [-bellatrix-fork-version] [-genesis-validators-root]
 
 Env & defaults:
 	[generate]
@@ -22,8 +22,10 @@ Env & defaults:
 	-fee-recipient  VALIDATOR_FEE_RECIPIENT  = 0x0000000000000000000000000000000000000000
 
 	[register]
-	-vd-file   VALIDATOR_DATA_FILE = ./validator_data.json
-	-mev-boost MEV_BOOST_ENDPOINT  = http://127.0.0.1:18550
+	-vd-file                  VALIDATOR_DATA_FILE     = ./validator_data.json
+	-mev-boost                MEV_BOOST_ENDPOINT      = http://127.0.0.1:18550
+	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
+	                                                    "0x60000069" (kiln)
 
 	[getHeader|getPayload]
 	-vd-file   VALIDATOR_DATA_FILE = ./validator_data.json
@@ -32,10 +34,11 @@ Env & defaults:
 	-en        ENGINE_ENDPOINT     = http://localhost:8545  - only used if -mm is passed or pre-bellatrix
 	-mm                                                     - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
 
-	           GENESIS_VALIDATORS_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000" - per network genesis validators root
-	                                     "0x99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad"   for kiln
+	-genesis-validators-root  GENESIS_VALIDATORS_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000" (mainnet) - network genesis validators root
+	                                                    "0x99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad" (kiln)
 
-	           FORK_VERSION            = "0x02000000" (Bellatrix) - per network fork version
+	-bellatrix-fork-version   BELLATRIX_FORK_VERSION  = "0x02000000" (mainnet) - network bellatrix fork version
+	                                                    "0x70000071" (kiln)
 ```
 
 ### Run mev-boost

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -25,18 +25,29 @@ Env & defaults:
 	-vd-file                  VALIDATOR_DATA_FILE     = ./validator_data.json
 	-mev-boost                MEV_BOOST_ENDPOINT      = http://127.0.0.1:18550
 	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
-	                                                    "0x60000069" (kiln)
+	                                                    "0x70000069" (kiln)
 
-	[getHeader|getPayload]
-	-vd-file   VALIDATOR_DATA_FILE = ./validator_data.json
-	-mev-boost MEV_BOOST_ENDPOINT  = http://127.0.0.1:18550
-	-bn        BEACON_ENDPOINT     = http://localhost:5052
-	-en        ENGINE_ENDPOINT     = http://localhost:8545  - only used if -mm is passed or pre-bellatrix
-	-mm                                                     - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
+	[getHeader]
+	-vd-file    VALIDATOR_DATA_FILE = ./validator_data.json
+	-mev-boost  MEV_BOOST_ENDPOINT  = http://127.0.0.1:18550
+	-bn         BEACON_ENDPOINT     = http://localhost:5052
+	-en         ENGINE_ENDPOINT     = http://localhost:8545  - only used if -mm is passed or pre-bellatrix
+	-mm                                                      - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
+
+	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
+	                                                    "0x70000069" (kiln)
+	[getPayload]
+	-vd-file    VALIDATOR_DATA_FILE = ./validator_data.json
+	-mev-boost  MEV_BOOST_ENDPOINT  = http://127.0.0.1:18550
+	-bn         BEACON_ENDPOINT     = http://localhost:5052
+	-en         ENGINE_ENDPOINT     = http://localhost:8545  - only used if -mm is passed or pre-bellatrix
+	-mm                                                      - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
 
 	-genesis-validators-root  GENESIS_VALIDATORS_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000" (mainnet) - network genesis validators root
 	                                                    "0x99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad" (kiln)
 
+	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
+	                                                    "0x70000069" (kiln)
 	-bellatrix-fork-version   BELLATRIX_FORK_VERSION  = "0x02000000" (mainnet) - network bellatrix fork version
 	                                                    "0x70000071" (kiln)
 ```

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -27,8 +27,8 @@ func doGenerateValidator(filePath string, gasLimit uint64, feeRecipient string) 
 	log.WithField("file", filePath).Info("Saved validator data")
 }
 
-func doRegisterValidator(v validatorPrivateData, boostEndpoint string) {
-	message, err := v.PrepareRegistrationMessage()
+func doRegisterValidator(v validatorPrivateData, boostEndpoint string, builderSigningDomain boostTypes.Domain) {
+	message, err := v.PrepareRegistrationMessage(builderSigningDomain)
 	if err != nil {
 		log.WithError(err).Fatal("Could not prepare registration message")
 	}
@@ -41,7 +41,7 @@ func doRegisterValidator(v validatorPrivateData, boostEndpoint string) {
 	log.WithError(err).Info("Registered validator")
 }
 
-func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string) boostTypes.GetHeaderResponse {
+func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, proposerSigningDomain boostTypes.Domain) boostTypes.GetHeaderResponse {
 	// Mergemock needs to call forkchoice update before getHeader, for non-mergemock beacon node this is a no-op
 	err := beaconNode.onGetHeader()
 	if err != nil {
@@ -73,12 +73,24 @@ func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon
 		log.WithError(err).WithField("currentBlockHash", currentBlockHash).Fatal("Could not get header")
 	}
 
-	log.WithField("header", getHeaderResp).Info("Got header from boost")
+	if getHeaderResp.Data.Message == nil {
+		log.Fatal("Did not receive correct header")
+	}
+	log.WithField("header", *getHeaderResp.Data.Message).Info("Got header from boost")
+
+	ok, err := boostTypes.VerifySignature(getHeaderResp.Data.Message, proposerSigningDomain, getHeaderResp.Data.Message.Pubkey[:], getHeaderResp.Data.Signature[:])
+	if err != nil {
+		log.WithError(err).Fatal("Could not verify builder bid signature")
+	}
+	if !ok {
+		log.Fatal("Incorrect builder bid signature")
+	}
+
 	return getHeaderResp
 }
 
-func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, signingDomain boostTypes.Domain) {
-	header := doGetHeader(v, boostEndpoint, beaconNode, engineEndpoint)
+func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, proposerSigningDomain boostTypes.Domain) {
+	header := doGetHeader(v, boostEndpoint, beaconNode, engineEndpoint, proposerSigningDomain)
 
 	blindedBeaconBlock := boostTypes.BlindedBeaconBlock{
 		Slot:          0,
@@ -99,8 +111,7 @@ func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beaco
 		},
 	}
 
-	signature, err := v.Sign(&blindedBeaconBlock, signingDomain)
-	log.WithField("msg", blindedBeaconBlock.Body).WithField("sd", signingDomain).WithField("sig", signature).Info("sign getPayload")
+	signature, err := v.Sign(&blindedBeaconBlock, proposerSigningDomain)
 	if err != nil {
 		log.WithError(err).Fatal("could not sign blinded beacon block")
 	}
@@ -114,7 +125,10 @@ func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beaco
 		log.WithError(err).Fatal("could not get payload")
 	}
 
-	log.WithField("payload", respPayload).Info("got payload from mev-boost")
+	if respPayload.Data == nil {
+		log.Fatal("Did not receive correct payload")
+	}
+	log.WithField("payload", *respPayload.Data).Info("got payload from mev-boost")
 }
 
 func main() {
@@ -152,11 +166,17 @@ func main() {
 
 	var genesisValidatorsRootStr string
 	envGenesisValidatorsRoot := getEnv("GENESIS_VALIDATORS_ROOT", "0x0000000000000000000000000000000000000000000000000000000000000000")
+	getHeaderCommand.StringVar(&genesisValidatorsRootStr, "genesis-validators-root", envGenesisValidatorsRoot, "Root of genesis validators")
 	getPayloadCommand.StringVar(&genesisValidatorsRootStr, "genesis-validators-root", envGenesisValidatorsRoot, "Root of genesis validators")
 
-	var forkVersionStr string
-	envForkVersion := getEnv("FORK_VERSION", "0x02000000")
-	getPayloadCommand.StringVar(&forkVersionStr, "fork-version", envForkVersion, "hex encoded fork version")
+	var genesisForkVersionStr string
+	envGenesisForkVersion := getEnv("GENESIS_FORK_VERSION", "0x00000000")
+	registerCommand.StringVar(&genesisForkVersionStr, "genesis-fork-version", envGenesisForkVersion, "hex encoded genesis fork version")
+
+	var bellatrixForkVersionStr string
+	envBellatrixForkVersion := getEnv("BELLATRIX_FORK_VERSION", "0x02000000")
+	getHeaderCommand.StringVar(&bellatrixForkVersionStr, "bellatrix-fork-version", envBellatrixForkVersion, "hex encoded bellatrix fork version")
+	getPayloadCommand.StringVar(&bellatrixForkVersionStr, "bellatrix-fork-version", envBellatrixForkVersion, "hex encoded bellatrix fork version")
 
 	var gasLimit uint64
 	envGasLimitStr := getEnv("VALIDATOR_GAS_LIMIT", "30000000")
@@ -186,26 +206,32 @@ func main() {
 		doGenerateValidator(validatorDataFile, gasLimit, validatorFeeRecipient)
 	case "register":
 		registerCommand.Parse(os.Args[2:])
-		doRegisterValidator(mustLoadValidator(validatorDataFile), boostEndpoint)
+		builderSigningDomain := computeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
+		doRegisterValidator(mustLoadValidator(validatorDataFile), boostEndpoint, builderSigningDomain)
 	case "getHeader":
 		getHeaderCommand.Parse(os.Args[2:])
-		doGetHeader(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint)
+		proposerSigningDomain := computeDomain(boostTypes.DomainTypeBeaconProposer, bellatrixForkVersionStr, genesisValidatorsRootStr)
+		doGetHeader(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint, proposerSigningDomain)
 	case "getPayload":
 		getPayloadCommand.Parse(os.Args[2:])
-		genesisValidatorsRoot := boostTypes.Root(common.HexToHash(genesisValidatorsRootStr))
-		forkVersionBytes, err := hexutil.Decode(forkVersionStr)
-		if err != nil || len(forkVersionBytes) > 4 {
-			fmt.Println("Invalid fork version passed")
-			os.Exit(1)
-		}
-		var forkVersion [4]byte
-		copy(forkVersion[:], forkVersionBytes[:4])
-		signingDomain := boostTypes.ComputeDomain(boostTypes.DomainTypeBeaconProposer, forkVersion, genesisValidatorsRoot)
-		doGetPayload(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint, signingDomain)
+		proposerSigningDomain := computeDomain(boostTypes.DomainTypeBeaconProposer, bellatrixForkVersionStr, genesisValidatorsRootStr)
+		doGetPayload(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint, proposerSigningDomain)
 	default:
 		fmt.Println("Expected generate|register|getHeader|getPayload subcommand")
 		os.Exit(1)
 	}
+}
+
+func computeDomain(domainType boostTypes.DomainType, forkVersionHex string, genesisValidatorsRootHex string) boostTypes.Domain {
+	genesisValidatorsRoot := boostTypes.Root(common.HexToHash(genesisValidatorsRootHex))
+	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
+	if err != nil || len(forkVersionBytes) > 4 {
+		fmt.Println("Invalid fork version passed")
+		os.Exit(1)
+	}
+	var forkVersion [4]byte
+	copy(forkVersion[:], forkVersionBytes[:4])
+	return boostTypes.ComputeDomain(domainType, forkVersion, genesisValidatorsRoot)
 }
 
 func getEnv(key string, defaultValue string) string {

--- a/cmd/test-cli/validator.go
+++ b/cmd/test-cli/validator.go
@@ -46,7 +46,7 @@ func newRandomValidator(gasLimit uint64, feeRecipient string) validatorPrivateDa
 	return validatorPrivateData{sk.Serialize(), pk.Compress(), hexutil.Uint64(gasLimit), feeRecipient}
 }
 
-func (v *validatorPrivateData) PrepareRegistrationMessage() ([]boostTypes.SignedValidatorRegistration, error) {
+func (v *validatorPrivateData) PrepareRegistrationMessage(builderSigningDomain boostTypes.Domain) ([]boostTypes.SignedValidatorRegistration, error) {
 	pk := boostTypes.PublicKey{}
 	pk.FromSlice(v.Pk)
 	addr, err := boostTypes.HexToAddress(v.FeeRecipientHex)
@@ -59,7 +59,7 @@ func (v *validatorPrivateData) PrepareRegistrationMessage() ([]boostTypes.Signed
 		Pubkey:       pk,
 		GasLimit:     uint64(v.GasLimit),
 	}
-	signature, err := v.Sign(&msg, boostTypes.DomainBuilder)
+	signature, err := v.Sign(&msg, builderSigningDomain)
 	if err != nil {
 		return []boostTypes.SignedValidatorRegistration{}, err
 	}

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -84,7 +84,7 @@ func TestRegisterValidator(t *testing.T) {
 			Timestamp:    1234356,
 			Pubkey:       _HexToPubkey("0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"),
 		},
-		Signature: _HexToSignature("0x8209b5391cd69f392b1f02dbc03bab61f574bb6bb54bf87b59e2a85bdc0756f7db6a71ce1b41b727a1f46ccc77b213bf0df1426177b5b29926b39956114421eaa36ec4602969f6f6370a44de44a6bce6dae2136e5fb594cce2a476354264d1ea"),
+		Signature: _HexToSignature("0x81510b571e22f89d1697545aac01c9ad0c1e7a3e778b3078bef524efae14990e58a6e960a152abd49de2e18d7fd3081c15d5c25867ccfad3d47beef6b39ac24b6b9fbf2cfa91c88f67aff750438a6841ec9e4a06a94ae41410c4f97b75ab284c"),
 	}
 	payload := []types.SignedValidatorRegistration{reg}
 


### PR DESCRIPTION
Updated to match the spec:
* register validator is now signed with genesis fork version
* getHeader is now checked to be signed with bellatrix fork version

Reference: https://github.com/ethereum/builder-specs/blob/main/specs/builder.md#containers and https://github.com/ethereum/builder-specs/blob/main/specs/builder.md#signing

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
