### PR TITLE
Add signature verifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run:
 	./mev-boost
 
 run-boost-with-relay:
-	./mev-boost -relays 127.0.0.1:28545
+	./mev-boost -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545
 
 run-dev:
 	go run cmd/mev-boost/main.go
@@ -58,7 +58,7 @@ run-mergemock-consensus:
 	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) consensus --slot-time=4s --engine http://127.0.0.1:8551 --builder http://127.0.0.1:18550 --slot-bound 10
 
 run-mergemock-relay:
-	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) relay --listen-addr 127.0.0.1:28545
+	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) relay --listen-addr 127.0.0.1:28545 --private-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52
 
 run-mergemock-integration: build
 	make -j3 run-boost-with-relay run-mergemock-consensus run-mergemock-relay

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ run-mergemock-consensus:
 	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) consensus --slot-time=4s --engine http://127.0.0.1:8551 --builder http://127.0.0.1:18550 --slot-bound 10
 
 run-mergemock-relay:
-	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) relay --listen-addr 127.0.0.1:28545 --private-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52
+	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) relay --listen-addr 127.0.0.1:28545 --secret-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52
 
 run-mergemock-integration: build
 	make -j3 run-boost-with-relay run-mergemock-consensus run-mergemock-relay

--- a/server/service.go
+++ b/server/service.go
@@ -144,6 +144,16 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 			http.Error(w, errInvalidSignature.Error(), http.StatusBadRequest)
 			return
 		}
+
+		ok, err := types.VerifySignature(registration.Message, types.DomainBuilder, registration.Message.Pubkey[:], registration.Signature[:])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !ok {
+			http.Error(w, errInvalidSignature.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	numSuccessRequestsToRelay := 0

--- a/server/service.go
+++ b/server/service.go
@@ -147,10 +147,12 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 
 		ok, err := types.VerifySignature(registration.Message, types.DomainBuilder, registration.Message.Pubkey[:], registration.Signature[:])
 		if err != nil {
+			log.WithError(err).Warn("error occurred while verifying signature")
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		if !ok {
+			log.WithError(err).Warn("failed to verify signature")
 			http.Error(w, errInvalidSignature.Error(), http.StatusBadRequest)
 			return
 		}

--- a/server/service.go
+++ b/server/service.go
@@ -308,7 +308,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 
 	for _, relay := range m.relays {
 		wg.Add(1)
-		go func(relayAddr string, relayPubKey types.PublicKey) {
+		go func(relayAddr string) {
 			defer wg.Done()
 			url := fmt.Sprintf("%s%s", relayAddr, pathGetPayload)
 			log := log.WithField("url", url)
@@ -349,7 +349,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 				"blockHash":   responsePayload.Data.BlockHash,
 				"blockNumber": responsePayload.Data.BlockNumber,
 			}).Info("getPayload: received payload from relay")
-		}(relay.Address, relay.PublicKey)
+		}(relay.Address)
 	}
 
 	// Wait for all requests to complete...


### PR DESCRIPTION
**Description:**

This PR adds support for signature verifications in the following handlers :

- [x] `registerValidator`
- [x] `getHeader`
- [ ] `getPayload`

**Problem(s) & goal(s):**

See #95 for more context.

**I have run these commands:**

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`

**Additional comments:**

For now, mergemock integration tests do not pass because the relay generates a random private key for each run and mev-boost does not have a way to know which one it is.
[I've created a PR](https://github.com/protolambda/mergemock/pull/51) which allows to provide a private key to mergemock's relay.