### PR TITLE
Add relay check on startup

### DIFF
--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -45,8 +45,8 @@ func main() {
 		log.WithError(err).Fatal("failed creating the server")
 	}
 
-	if *relayCheck {
-		server.CheckRelays()
+	if *relayCheck && !server.CheckRelays() {
+		log.Fatal("relays unavailable")
 	}
 
 	log.Println("listening on", *listenAddr)

--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -39,14 +39,14 @@ func main() {
 	}
 	log.WithField("relays", relays).Infof("using %d relays", len(relays))
 
-	if *relayCheck {
-		relayStartupCheck(relays)
-	}
-
 	relayTimeout := time.Duration(*relayTimeoutMs) * time.Millisecond
 	server, err := server.NewBoostService(*listenAddr, relays, log, relayTimeout)
 	if err != nil {
 		log.WithError(err).Fatal("failed creating the server")
+	}
+
+	if *relayCheck {
+		server.CheckRelays()
 	}
 
 	log.Println("listening on", *listenAddr)
@@ -80,16 +80,4 @@ func parseRelayURLs(relayURLs string) []server.RelayEntry {
 		ret = append(ret, relay)
 	}
 	return ret
-}
-
-func relayStartupCheck(relays []server.RelayEntry) error {
-	log.Fatal("TODO: Checking relays...")
-	for _, relay := range relays {
-		log.WithField("relay", relay).Info("Checking relay")
-		// err := relay.Check()
-		// if err != nil {
-		//     log.WithError(err).WithField("relay", relay).Fatal("Relay check failed")
-		// }
-	}
-	return nil
 }

--- a/server/service.go
+++ b/server/service.go
@@ -358,18 +358,15 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 
 // CheckRelays sends a request to each one of the relays previously registered to get their status
 func (m *BoostService) CheckRelays() bool {
-	var status = false
-
 	for _, relay := range m.relays {
 		m.log.WithField("relay", relay).Info("Checking relay")
 
 		err := SendHTTPRequest(context.Background(), m.httpClient, http.MethodGet, relay.Address+pathStatus, nil, nil)
 		if err != nil {
 			m.log.WithError(err).WithField("relay", relay).Error("relay check failed")
-		} else {
-			status = true
+			return false
 		}
 	}
 
-	return status
+	return true
 }

--- a/server/service.go
+++ b/server/service.go
@@ -355,3 +355,21 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 		return
 	}
 }
+
+// CheckRelays sends a request to each one of the relays previously registered to get their status
+func (m *BoostService) CheckRelays() bool {
+	var status = false
+
+	for _, relay := range m.relays {
+		m.log.WithField("relay", relay).Info("Checking relay")
+
+		err := SendHTTPRequest(context.Background(), m.httpClient, http.MethodGet, relay.Address+pathStatus, nil, nil)
+		if err != nil {
+			m.log.WithError(err).WithField("relay", relay)
+		} else {
+			status = true
+		}
+	}
+
+	return status
+}

--- a/server/service.go
+++ b/server/service.go
@@ -365,7 +365,7 @@ func (m *BoostService) CheckRelays() bool {
 
 		err := SendHTTPRequest(context.Background(), m.httpClient, http.MethodGet, relay.Address+pathStatus, nil, nil)
 		if err != nil {
-			m.log.WithError(err).WithField("relay", relay)
+			m.log.WithError(err).WithField("relay", relay).Error("relay check failed")
 		} else {
 			status = true
 		}

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -331,3 +331,21 @@ func TestGetPayload(t *testing.T) {
 		require.Equal(t, http.StatusBadGateway, rr.Code, rr.Body.String())
 	})
 }
+
+func TestCheckRelays(t *testing.T) {
+	t.Run("At least one relay is okay", func(t *testing.T) {
+		backend := newTestBackend(t, 3, time.Second)
+		status := backend.boost.CheckRelays()
+
+		require.Equal(t, true, status)
+	})
+
+	t.Run("Every relays are down", func(t *testing.T) {
+		backend := newTestBackend(t, 1, time.Second)
+		backend.relays[0].Server.Close()
+
+		status := backend.boost.CheckRelays()
+
+		require.Equal(t, false, status)
+	})
+}


### PR DESCRIPTION
**Related issue(s):**

For more information, see #95.

**Description:**

This PR adds a relay check whenever the server starts.
It queries each relay on their `status` endpoint.

For now, no behavior is associated to a missing relay.

**Additional context & references:**

I can add some logic when unavailable relays are found.
We can discuss about this below.

For now, if at least one relay is available, the method returns true. Otherwise if none are available, it returns false.

---

**I have run these commands:**

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
