### PR TITLE
mev-boost cli flags for setting genesis fork version, computing corre…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run:
 	./mev-boost
 
 run-boost-with-relay:
-	./mev-boost -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545
+	./mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545
 
 run-dev:
 	go run cmd/mev-boost/main.go

--- a/README.md
+++ b/README.md
@@ -69,14 +69,18 @@ go install honnef.co/go/tools/cmd/staticcheck@master
 
 ```bash
 make build
-./mev-boost -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@localhost:28545
+./mev-boost -h
+./mev-boost -kiln -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@localhost:28545
 ```
 
 Alternatively, run mev-boost without compile step:
 
 ```bash
-go run cmd/mev-boost/main.go -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@localhost:28545
+go run cmd/mev-boost/main.go -h
+go run cmd/mev-boost/main.go -kiln -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@localhost:28545
 ```
+
+Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-kiln`/`-ropsten`).
 
 If the test or target application crashes with an "illegal instruction" exception, run/rebuild with CGO_CFLAGS environment variable set to `-O -D__BLST_PORTABLE__`. This error also happens if you are on an ARM-based system, including the Apple M1/M2 chip.
 

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -36,7 +36,7 @@ func newTestBackend(t *testing.T, numRelays int, relayTimeout time.Duration) *te
 		backend.relays[i] = newMockRelay(t, blsPrivateKey)
 		relayEntries[i] = backend.relays[i].RelayEntry
 	}
-	service, err := NewBoostService("localhost:12345", relayEntries, testLog, relayTimeout)
+	service, err := NewBoostService("localhost:12345", relayEntries, testLog, "0x00000000", relayTimeout)
 	require.NoError(t, err)
 
 	backend.boost = service
@@ -63,7 +63,7 @@ func (be *testBackend) request(t *testing.T, method string, path string, payload
 
 func TestNewBoostServiceErrors(t *testing.T) {
 	t.Run("errors when no relays", func(t *testing.T) {
-		_, err := NewBoostService(":123", []RelayEntry{}, testLog, time.Second)
+		_, err := NewBoostService(":123", []RelayEntry{}, testLog, "0x00000000", time.Second)
 		require.Error(t, err)
 	})
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/flashbots/go-boost-utils/types"
 )
 
 // SendHTTPRequest - prepare and send HTTP request, marshaling the payload if any, and decoding the response if dst is set
@@ -54,4 +59,17 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 	}
 
 	return nil
+}
+
+// ComputeDomain computes the signing domain
+func ComputeDomain(domainType types.DomainType, forkVersionHex string, genesisValidatorsRootHex string) (domain types.Domain, err error) {
+	genesisValidatorsRoot := types.Root(common.HexToHash(genesisValidatorsRootHex))
+	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
+	if err != nil || len(forkVersionBytes) > 4 {
+		err = errors.New("invalid fork version passed")
+		return domain, err
+	}
+	var forkVersion [4]byte
+	copy(forkVersion[:], forkVersionBytes[:4])
+	return types.ComputeDomain(domainType, forkVersion, genesisValidatorsRoot), nil
 }


### PR DESCRIPTION
correct signing domain is required to verify relay signatures, and for this we need the genesis fork version

---

I have run these commands:

* [X] `make lint`
* [X] `make test`
* [X] `make run-mergemock-integration`
* [X] `go mod tidy`
