### PR TITLE
Simplify OK responses across handlers

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -27,6 +27,7 @@ var (
 )
 
 var nilHash = types.Hash{}
+var nilResponse = struct{}{}
 
 type httpErrorResp struct {
 	Code    int    `json:"code"`
@@ -42,18 +43,13 @@ func respondError(w http.ResponseWriter, code int, message string) {
 }
 
 func respondOK(w http.ResponseWriter, result any) error {
-	var err error
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	if result == nil {
-		_, err = fmt.Fprintf(w, `{}`)
-	} else {
-		err = json.NewEncoder(w).Encode(result)
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		return err
 	}
-
-	return err
+	return nil
 }
 
 // BoostService TODO
@@ -126,7 +122,7 @@ func (m *BoostService) StartHTTPServer() error {
 }
 
 func (m *BoostService) handleRoot(w http.ResponseWriter, req *http.Request) {
-	respondOK(w, nil)
+	respondOK(w, nilResponse)
 }
 
 func (m *BoostService) handleStatus(w http.ResponseWriter, req *http.Request) {
@@ -198,7 +194,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 	wg.Wait()
 
 	if numSuccessRequestsToRelay > 0 {
-		respondOK(w, nil)
+		respondOK(w, nilResponse)
 	} else {
 		respondError(w, http.StatusBadGateway, errNoSuccessfulRelayResponse.Error())
 	}

--- a/server/service.go
+++ b/server/service.go
@@ -41,6 +41,21 @@ func respondError(w http.ResponseWriter, code int, message string) {
 	}
 }
 
+func respondOK(w http.ResponseWriter, result any) error {
+	var err error
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if result == nil {
+		_, err = fmt.Fprintf(w, `{}`)
+	} else {
+		err = json.NewEncoder(w).Encode(result)
+	}
+
+	return err
+}
+
 // BoostService TODO
 type BoostService struct {
 	listenAddr string
@@ -111,9 +126,7 @@ func (m *BoostService) StartHTTPServer() error {
 }
 
 func (m *BoostService) handleRoot(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, `{}`)
+	respondOK(w, nil)
 }
 
 func (m *BoostService) handleStatus(w http.ResponseWriter, req *http.Request) {
@@ -185,9 +198,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 	wg.Wait()
 
 	if numSuccessRequestsToRelay > 0 {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{}`)
+		respondOK(w, nil)
 	} else {
 		respondError(w, http.StatusBadGateway, errNoSuccessfulRelayResponse.Error())
 	}
@@ -288,12 +299,9 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(result); err != nil {
+	if err := respondOK(w, result); err != nil {
 		log.WithError(err).Warn("error writing response getting payload header")
 		respondError(w, http.StatusInternalServerError, "internal server error")
-		return
 	}
 }
 
@@ -373,12 +381,9 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(result); err != nil {
+	if err := respondOK(w, result); err != nil {
 		log.WithError(err).Warn("error writing response getting payload")
 		respondError(w, http.StatusInternalServerError, "internal server error")
-		return
 	}
 }
 

--- a/server/service.go
+++ b/server/service.go
@@ -45,11 +45,7 @@ func respondError(w http.ResponseWriter, code int, message string) {
 func respondOK(w http.ResponseWriter, result any) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		return err
-	}
-	return nil
+	return json.NewEncoder(w).Encode(result)
 }
 
 // BoostService TODO

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -103,7 +103,7 @@ func TestWebserverRootHandler(t *testing.T) {
 	rr := httptest.NewRecorder()
 	backend.boost.getRouter().ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
-	require.Equal(t, "{}", rr.Body.String())
+	require.Equal(t, "{}\n", rr.Body.String())
 }
 
 // Example good registerValidator payload


### PR DESCRIPTION
## Description
This PR adds a new method, `respondOK`, which avoids code duplication across the mev-boost server's handlers.

## Context & references
It's similar to the `respondError` method, but returns a 200 Status code and an optional element instead.

## Additional comments

---

## I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
