### PR TITLE
Add auto releaser for docker image

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,38 @@
+name: Docker Auto Releaser
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  releaser:
+    name: Docker Image Auto Releaser
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Set tag version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: flashbots/mev-boost:latest,flashbots/mev-boost:${{ steps.vars.outputs.tag }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Description
This PR adds a job which is triggered every time a new tag of the following form is pushed : `v*.*.*`
This job will build and push the docker image to the flashbots repository on Docker Hub.

Current supported platforms :
- `linux/amd64`
- `linux/arm64`

Two tags are created and pushed :
1. The one corresponding to the tag pushed
2. The `latest` one is updated

## Context & references


## Additional comments
@metachris You'll need to setup two github secrets for this repository :
1. `DOCKERHUB_USERNAME`
3. `DOCKERHUB_TOKEN`

---

## I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
