### PR TITLE
registerValidator: remove signature check, leave up for relay

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -133,30 +133,6 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 		return
 	}
 
-	for _, registration := range payload {
-		if len(registration.Message.Pubkey) != 48 {
-			respondError(w, http.StatusBadRequest, errInvalidPubkey.Error())
-			return
-		}
-
-		if len(registration.Signature) != 96 {
-			respondError(w, http.StatusBadRequest, errInvalidSignature.Error())
-			return
-		}
-
-		ok, err := types.VerifySignature(registration.Message, m.builderSigningDomain, registration.Message.Pubkey[:], registration.Signature[:])
-		if err != nil {
-			log.WithError(err).WithField("registration", registration).Error("error verifying registerValidator signature")
-			respondError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		if !ok {
-			log.WithError(err).WithField("registration", registration).Error("failed to verify registerValidator signature")
-			respondError(w, http.StatusBadRequest, errInvalidSignature.Error())
-			return
-		}
-	}
-
 	numSuccessRequestsToRelay := 0
 	var mu sync.Mutex
 

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -191,19 +191,6 @@ func TestRegisterValidator(t *testing.T) {
 		require.Equal(t, http.StatusBadGateway, rr.Code)
 		require.Equal(t, 2, backend.relays[0].GetRequestCount(path))
 	})
-
-	t.Run("Invalid validator signature", func(t *testing.T) {
-		// signature does not match message
-		invalidPayload := []types.SignedValidatorRegistration{reg}
-		invalidPayload[0].Signature = _HexToSignature(
-			"0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9")
-
-		backend := newTestBackend(t, 1, time.Second)
-		rr := backend.request(t, http.MethodPost, path, invalidPayload)
-		require.Equal(t, `{"code":400,"message":"invalid signature"}`+"\n", rr.Body.String())
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
-	})
 }
 
 func TestGetHeader(t *testing.T) {


### PR DESCRIPTION
## Description

Remove registerValidator signature checks, leave the error handling up to the relays

## Context & references

#170 

---

## I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
