### PR TITLE
Add verifications in getHeader handler

### DIFF
--- a/server/mock_relay.go
+++ b/server/mock_relay.go
@@ -144,7 +144,8 @@ func (m *mockRelay) MakeGetHeaderResponse(value uint64, hash, publicKey string) 
 	// Fill the payload with custom values.
 	message := &types.BuilderBid{
 		Header: &types.ExecutionPayloadHeader{
-			BlockHash: _HexToHash(hash),
+			BlockHash:  _HexToHash(hash),
+			ParentHash: _HexToHash("0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"),
 		},
 		Value:  types.IntToU256(value),
 		Pubkey: _HexToPubkey(publicKey),

--- a/server/service.go
+++ b/server/service.go
@@ -281,7 +281,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 
 			// Verify response coherence with proposer's input data
-			if responsePayload.Data != nil && responsePayload.Data.Message.Header.ParentHash.String() != parentHashHex {
+			if responsePayload.Data.Message.Header.ParentHash.String() != parentHashHex {
 				log.WithError(errInvalidParentHash).Error("proposer and relay parent hashes are not the same")
 				return
 			}

--- a/server/service.go
+++ b/server/service.go
@@ -20,7 +20,6 @@ import (
 var (
 	errInvalidSlot               = errors.New("invalid slot")
 	errInvalidHash               = errors.New("invalid hash")
-	errInvalidParentHash         = errors.New("invalid parent hash")
 	errInvalidPubkey             = errors.New("invalid pubkey")
 	errInvalidSignature          = errors.New("invalid signature")
 	errNoSuccessfulRelayResponse = errors.New("no successful relay response")
@@ -281,8 +280,12 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 
 			// Verify response coherence with proposer's input data
-			if responsePayload.Data.Message.Header.ParentHash.String() != parentHashHex {
-				log.WithError(errInvalidParentHash).Error("proposer and relay parent hashes are not the same")
+			responseParentHash := responsePayload.Data.Message.Header.ParentHash.String()
+			if responseParentHash != parentHashHex {
+				log.WithFields(logrus.Fields{
+					"originalParentHash": parentHashHex,
+					"responseParentHash": responseParentHash,
+				}).Error("proposer and relay parent hashes are not the same")
 				return
 			}
 

--- a/server/service.go
+++ b/server/service.go
@@ -20,6 +20,7 @@ import (
 var (
 	errInvalidSlot               = errors.New("invalid slot")
 	errInvalidHash               = errors.New("invalid hash")
+	errInvalidParentHash         = errors.New("invalid parent hash")
 	errInvalidPubkey             = errors.New("invalid pubkey")
 	errInvalidSignature          = errors.New("invalid signature")
 	errNoSuccessfulRelayResponse = errors.New("no successful relay response")
@@ -276,6 +277,12 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 			if !ok {
 				log.WithError(errInvalidSignature).Error("failed to verify relay signature")
+				return
+			}
+
+			// Verify response coherence with proposer's input data
+			if responsePayload.Data != nil && responsePayload.Data.Message.Header.ParentHash.String() != parentHashHex {
+				log.WithError(errInvalidParentHash).Error("proposer and relay parent hashes are not the same")
 				return
 			}
 

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -366,6 +366,16 @@ func TestGetHeader(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
+
+	t.Run("Invalid parent hash", func(t *testing.T) {
+		backend := newTestBackend(t, 1, time.Second)
+
+		invalidParentHashPath := getPath(1, types.Hash{}, pubkey)
+		rr := backend.request(t, http.MethodGet, invalidParentHashPath, nil)
+
+		require.Equal(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
+		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
+	})
 }
 
 func TestGetPayload(t *testing.T) {


### PR DESCRIPTION
## 📝 Summary

This PR adds the following verification(s) in the `getHeader` handler :
- Checks if the `parent_hash` in the response (given by the relay) is the same as the one in the request (the one given by the proposer)
- The same way, checks if the `public_key` in the response is the same as the one in the request

It closes #174.

## ⛱ Motivation and Context

More context about this PR can be found in #174.

## 📚 References

The `getHeader` handler is defined [here](https://ethereum.github.io/builder-specs/#/Builder/getHeader)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
