### PR TITLE
status-check: proxy relay check until first responds ok, enabled with…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Please start by reading our [code of conduct](CODE_OF_CONDUCT.md).
 Install a few dev dependencies:
 
 ```bash
-go install github.com/ferranbt/fastssz/sszgen@latest
 go install github.com/mgechev/revive@latest
 go install honnef.co/go/tools/cmd/staticcheck@master
+go install github.com/ferranbt/fastssz/sszgen@latest
 ```
 
 Look at the [README for instructions to install the dependencies and build `mev-boost`](README.md#install)

--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -94,13 +94,22 @@ func main() {
 	log.WithField("relays", relays).Infof("using %d relays", len(relays))
 
 	relayTimeout := time.Duration(*relayTimeoutMs) * time.Millisecond
-	server, err := server.NewBoostService(*listenAddr, relays, log, genesisForkVersionHex, relayTimeout)
+
+	opts := server.BoostServiceOpts{
+		Log:                   log,
+		ListenAddr:            *listenAddr,
+		Relays:                relays,
+		GenesisForkVersionHex: genesisForkVersionHex,
+		RelayRequestTimeout:   relayTimeout,
+		RelayCheck:            *relayCheck,
+	}
+	server, err := server.NewBoostService(opts)
 	if err != nil {
 		log.WithError(err).Fatal("failed creating the server")
 	}
 
 	if *relayCheck && !server.CheckRelays() {
-		log.Fatal("relays unavailable")
+		log.Fatal("no relay available")
 	}
 
 	log.Println("listening on", *listenAddr)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -37,7 +37,16 @@ func newTestBackend(t *testing.T, numRelays int, relayTimeout time.Duration) *te
 		backend.relays[i] = newMockRelay(t, blsPrivateKey)
 		relayEntries[i] = backend.relays[i].RelayEntry
 	}
-	service, err := NewBoostService("localhost:12345", relayEntries, testLog, "0x00000000", relayTimeout)
+
+	opts := BoostServiceOpts{
+		Log:                   testLog,
+		ListenAddr:            "localhost:12345",
+		Relays:                relayEntries,
+		GenesisForkVersionHex: "0x00000000",
+		RelayRequestTimeout:   relayTimeout,
+		RelayCheck:            true,
+	}
+	service, err := NewBoostService(opts)
 	require.NoError(t, err)
 
 	backend.boost = service
@@ -64,7 +73,7 @@ func (be *testBackend) request(t *testing.T, method string, path string, payload
 
 func TestNewBoostServiceErrors(t *testing.T) {
 	t.Run("errors when no relays", func(t *testing.T) {
-		_, err := NewBoostService(":123", []RelayEntry{}, testLog, "0x00000000", time.Second)
+		_, err := NewBoostService(BoostServiceOpts{testLog, ":123", []RelayEntry{}, "0x00000000", time.Second, true})
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## 📝 Summary

The status check API will only check relay status if enabled with `-relay-check` cli flag, and then return OK as soon as one relay returns ok.

Future update: continuously check relay status, and return instantly on status API call.

## ⛱ Motivation and Context

See also #169

closes #184 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
