### PR TITLE
update go-boost-utils to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/ethereum/go-ethereum v1.10.17
-	github.com/flashbots/go-boost-utils v0.1.2
+	github.com/flashbots/go-boost-utils v0.2.0
 	github.com/flashbots/go-utils v0.4.5
 	github.com/gorilla/mux v1.8.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/ferranbt/fastssz v0.1.1-0.20220303160658-88bb965b6747 h1:0w9ZW2gY6Ws640PkDsyB1CK1ndAPJJ0mJbsDojQFl5c=
 github.com/ferranbt/fastssz v0.1.1-0.20220303160658-88bb965b6747/go.mod h1:S8yiDeAXy8f88W4Ul+0dBMPx49S05byYbmZD6Uv94K4=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
-github.com/flashbots/go-boost-utils v0.1.2 h1:xcwO6rhLmdbZ+ttN8PjHQynqY1pm+RCA56eGP9wPp10=
-github.com/flashbots/go-boost-utils v0.1.2/go.mod h1:v4f01OjPm5jFjzVhcJEKHLFZzX/yTeme9284Tbuah8s=
+github.com/flashbots/go-boost-utils v0.2.0 h1:TeNDTMPt4P2hXoHUgt3t0LxfuABthtz1J2JEQSwDhT4=
+github.com/flashbots/go-boost-utils v0.2.0/go.mod h1:v4f01OjPm5jFjzVhcJEKHLFZzX/yTeme9284Tbuah8s=
 github.com/flashbots/go-utils v0.4.5 h1:xTrVcfxQ+qpVVPyRBWUllwZAxbAijE06d9N7e7mmmlM=
 github.com/flashbots/go-utils v0.4.5/go.mod h1:3YKyfbtetVIXuWKbZ9WmK8bSF20hSFXk0wCWDNHYFvE=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=


### PR DESCRIPTION
## 📝 Summary

Update of go-boost-utils fixes https://github.com/flashbots/go-boost-utils/issues/11

---

## ✅ I have run these commands

* [X] `make lint`
* [X] `make test`
* [X] `make run-mergemock-integration`
* [X] `go mod tidy`
