### PR TITLE
Move mergemock-integration to separate bash script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,4 @@ jobs:
 
       - name: Run mergemock consensus tests
         run: |
-          make MERGEMOCK_DIR=./mergemock run-mergemock-relay &
-          make run-boost-with-relay &
-          sleep 5
-          make MERGEMOCK_DIR=./mergemock run-mergemock-consensus
+          make MERGEMOCK_DIR=./mergemock run-mergemock-integration

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-MERGEMOCK_DIR=../mergemock
-MERGEMOCK_BIN=./mergemock
-
 VERSION ?= $(shell git describe --tags --always --dirty="-dev")
 DOCKER_REPO := flashbots/mev-boost
 
@@ -45,23 +42,11 @@ cover-html:
 run:
 	./mev-boost
 
-run-boost-with-relay:
-	./mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545
-
 run-dev:
 	go run cmd/mev-boost/main.go
 
-run-mergemock-engine:
-	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) engine --listen-addr 127.0.0.1:8551
-
-run-mergemock-consensus:
-	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) consensus --slot-time=4s --engine http://127.0.0.1:8551 --builder http://127.0.0.1:18550 --slot-bound 10
-
-run-mergemock-relay:
-	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) relay --listen-addr 127.0.0.1:28545 --secret-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52
-
 run-mergemock-integration: build
-	make -j3 run-boost-with-relay run-mergemock-consensus run-mergemock-relay
+	./scripts/run_mergemock_integration.sh
 
 build-for-docker:
 	GOOS=linux go build -ldflags "-X main.version=${VERSION}" -v -o mev-boost ./cmd/mev-boost

--- a/scripts/run_mergemock_integration.sh
+++ b/scripts/run_mergemock_integration.sh
@@ -12,22 +12,13 @@ MERGEMOCK_BIN=${MERGEMOCK_BIN:-./mergemock}
 #
 # This function will ensure there are no lingering processes afterwards.
 #
-BOOST_WITH_RELAY_PID=
-MERGEMOCK_RELAY_PID=
-MERGEMOCK_CONSENSUS_PID=
 cleanup() {
-  if ps -p $BOOST_WITH_RELAY_PID &>/dev/null; then
-    disown $BOOST_WITH_RELAY_PID
-    kill -9 $BOOST_WITH_RELAY_PID &>/dev/null
-  fi
-  if ps -p $MERGEMOCK_RELAY_PID &>/dev/null; then
-    disown $MERGEMOCK_RELAY_PID
-    kill -9 $MERGEMOCK_RELAY_PID &>/dev/null
-  fi
-  if ps -p $MERGEMOCK_CONSENSUS_PID &>/dev/null; then
-    disown $MERGEMOCK_CONSENSUS_PID
-    kill -9 $MERGEMOCK_CONSENSUS_PID &>/dev/null
-  fi
+  for pid in $BOOST_WITH_RELAY_PID $MERGEMOCK_RELAY_PID $MERGEMOCK_CONSENSUS_PID; do
+    if ps -p $pid &>/dev/null; then
+      disown $pid
+      kill -9 $pid &>/dev/null
+    fi
+  done
 }
 trap cleanup exit
 

--- a/scripts/run_mergemock_integration.sh
+++ b/scripts/run_mergemock_integration.sh
@@ -12,21 +12,21 @@ MERGEMOCK_BIN=${MERGEMOCK_BIN:-./mergemock}
 #
 # This function will ensure there are no lingering processes afterwards.
 #
-RUN_BOOST_WITH_RELAY_PID=
-RUN_MERGEMOCK_RELAY_PID=
-RUN_MERGEMOCK_CONSENSUS_PID=
+BOOST_WITH_RELAY_PID=
+MERGEMOCK_RELAY_PID=
+MERGEMOCK_CONSENSUS_PID=
 cleanup() {
-  if ps -p $RUN_BOOST_WITH_RELAY_PID &>/dev/null; then
-    disown $RUN_BOOST_WITH_RELAY_PID
-    kill -9 $RUN_BOOST_WITH_RELAY_PID &>/dev/null
+  if ps -p $BOOST_WITH_RELAY_PID &>/dev/null; then
+    disown $BOOST_WITH_RELAY_PID
+    kill -9 $BOOST_WITH_RELAY_PID &>/dev/null
   fi
-  if ps -p $RUN_MERGEMOCK_RELAY_PID &>/dev/null; then
-    disown $RUN_MERGEMOCK_RELAY_PID
-    kill -9 $RUN_MERGEMOCK_RELAY_PID &>/dev/null
+  if ps -p $MERGEMOCK_RELAY_PID &>/dev/null; then
+    disown $MERGEMOCK_RELAY_PID
+    kill -9 $MERGEMOCK_RELAY_PID &>/dev/null
   fi
-  if ps -p $RUN_MERGEMOCK_CONSENSUS_PID &>/dev/null; then
-    disown $RUN_MERGEMOCK_CONSENSUS_PID
-    kill -9 $RUN_MERGEMOCK_CONSENSUS_PID &>/dev/null
+  if ps -p $MERGEMOCK_CONSENSUS_PID &>/dev/null; then
+    disown $MERGEMOCK_CONSENSUS_PID
+    kill -9 $MERGEMOCK_CONSENSUS_PID &>/dev/null
   fi
 }
 trap cleanup exit
@@ -35,7 +35,7 @@ trap cleanup exit
 # Start mev-boost.
 #
 $PROJECT_DIR/mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545 &
-RUN_BOOST_WITH_RELAY_PID=$!
+BOOST_WITH_RELAY_PID=$!
 echo "Waiting for mev-boost to become available..."
 while ! nc -z localhost 18550; do
   sleep 0.1
@@ -46,7 +46,7 @@ done
 #
 pushd $MERGEMOCK_DIR >/dev/null
 $MERGEMOCK_BIN relay --listen-addr 127.0.0.1:28545 --secret-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52 &
-RUN_MERGEMOCK_RELAY_PID=$!
+MERGEMOCK_RELAY_PID=$!
 echo "Waiting for relay to become available..."
 while ! nc -z localhost 28545; do
   sleep 0.1
@@ -56,10 +56,10 @@ done
 # Mock the consensus.
 #
 $MERGEMOCK_BIN consensus --slot-time=4s --engine http://127.0.0.1:8551 --builder http://127.0.0.1:18550 --slot-bound 10 &
-RUN_MERGEMOCK_CONSENSUS_PID=$!
+MERGEMOCK_CONSENSUS_PID=$!
 popd >/dev/null
 
 #
 # The script will exit when this process finishes.
 #
-wait $RUN_MERGEMOCK_CONSENSUS_PID
+wait $MERGEMOCK_CONSENSUS_PID

--- a/scripts/run_mergemock_integration.sh
+++ b/scripts/run_mergemock_integration.sh
@@ -21,9 +21,18 @@ RUN_BOOST_WITH_RELAY_PID=
 RUN_MERGEMOCK_RELAY_PID=
 RUN_MERGEMOCK_CONSENSUS_PID=
 cleanup() {
-  kill -9 $RUN_BOOST_WITH_RELAY_PID 2>/dev/null
-  kill -9 $RUN_MERGEMOCK_RELAY_PID 2>/dev/null
-  kill -9 $RUN_MERGEMOCK_CONSENSUS_PID 2>/dev/null
+  if ps -p $RUN_BOOST_WITH_RELAY_PID &>/dev/null; then
+    disown $RUN_BOOST_WITH_RELAY_PID
+    kill -9 $RUN_BOOST_WITH_RELAY_PID &>/dev/null
+  fi
+  if ps -p $RUN_MERGEMOCK_RELAY_PID &>/dev/null; then
+    disown $RUN_MERGEMOCK_RELAY_PID
+    kill -9 $RUN_MERGEMOCK_RELAY_PID &>/dev/null
+  fi
+  if ps -p $RUN_MERGEMOCK_CONSENSUS_PID &>/dev/null; then
+    disown $RUN_MERGEMOCK_CONSENSUS_PID
+    kill -9 $RUN_MERGEMOCK_CONSENSUS_PID &>/dev/null
+  fi
 }
 trap cleanup exit
 

--- a/scripts/run_mergemock_integration.sh
+++ b/scripts/run_mergemock_integration.sh
@@ -4,15 +4,10 @@ set -euo pipefail
 PROJECT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 
 #
-# Ensure that mergemock exists.
+# Default to these values for mergemock.
 #
 MERGEMOCK_DIR=${MERGEMOCK_DIR:-$PROJECT_DIR/../mergemock}
 MERGEMOCK_BIN=${MERGEMOCK_BIN:-./mergemock}
-if [ ! -f "$MERGEMOCK_DIR/$MERGEMOCK_BIN" ]; then
-  echo "Cannot find mergemock. Expected at: $(realpath $MERGEMOCK_DIR/$MERGEMOCK_BIN)"
-  echo "Please build clone and build mergemock. Then re-run this."
-  exit -1
-fi
 
 #
 # This function will ensure there are no lingering processes afterwards.

--- a/scripts/run_mergemock_integration.sh
+++ b/scripts/run_mergemock_integration.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+
+#
+# Ensure that mergemock exists.
+#
+MERGEMOCK_DIR=${MERGEMOCK_DIR:-$PROJECT_DIR/../mergemock}
+MERGEMOCK_BIN=${MERGEMOCK_BIN:-./mergemock}
+if [ ! -f "$MERGEMOCK_DIR/$MERGEMOCK_BIN" ]; then
+  echo "Cannot find mergemock. Expected at: $(realpath $MERGEMOCK_DIR/$MERGEMOCK_BIN)"
+  echo "Please build clone and build mergemock. Then re-run this."
+  exit -1
+fi
+
+#
+# This function will ensure there are no lingering processes afterwards.
+#
+RUN_BOOST_WITH_RELAY_PID=
+RUN_MERGEMOCK_RELAY_PID=
+RUN_MERGEMOCK_CONSENSUS_PID=
+cleanup() {
+  kill -9 $RUN_BOOST_WITH_RELAY_PID 2>/dev/null
+  kill -9 $RUN_MERGEMOCK_RELAY_PID 2>/dev/null
+  kill -9 $RUN_MERGEMOCK_CONSENSUS_PID 2>/dev/null
+}
+trap cleanup exit
+
+#
+# Start mev-boost.
+#
+$PROJECT_DIR/mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545 &
+RUN_BOOST_WITH_RELAY_PID=$!
+echo "Waiting for mev-boost to become available..."
+while ! nc -z localhost 18550; do
+  sleep 0.1
+done
+
+#
+# Mock the relay.
+#
+pushd $MERGEMOCK_DIR >/dev/null
+$MERGEMOCK_BIN relay --listen-addr 127.0.0.1:28545 --secret-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52 &
+RUN_MERGEMOCK_RELAY_PID=$!
+echo "Waiting for relay to become available..."
+while ! nc -z localhost 28545; do
+  sleep 0.1
+done
+
+#
+# Mock the consensus.
+#
+$MERGEMOCK_BIN consensus --slot-time=4s --engine http://127.0.0.1:8551 --builder http://127.0.0.1:18550 --slot-bound 10 &
+RUN_MERGEMOCK_CONSENSUS_PID=$!
+popd >/dev/null
+
+#
+# The script will exit when this process finishes.
+#
+wait $RUN_MERGEMOCK_CONSENSUS_PID


### PR DESCRIPTION
## 📝 Summary

This moves the mergemock integration tests to a separate bash script. This script will properly wait for each step to finish initializing before starting the next. The mergemock environment variables should still work as expected.

## ⛱ Motivation and Context

Fixes #192. I also like doing stuff.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
