### PR TITLE
Cleanup makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Install a few dev dependencies:
 ```bash
 go install github.com/mgechev/revive@latest
 go install honnef.co/go/tools/cmd/staticcheck@master
-go install github.com/ferranbt/fastssz/sszgen@latest
 ```
 
 Look at the [README for instructions to install the dependencies and build `mev-boost`](README.md#installing)

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ lint:
 	go vet ./...
 	staticcheck ./...
 
-.PHONY: generate-ssz
-generate-ssz:
-	rm -f types/builder_encoding.go
-	sszgen --path types --include ../go-ethereum/common/hexutil --objs Eth1Data,BeaconBlockHeader,SignedBeaconBlockHeader,ProposerSlashing,Checkpoint,AttestationData,IndexedAttestation,AttesterSlashing,Attestation,Deposit,VoluntaryExit,SyncAggregate,ExecutionPayloadHeader,VersionedExecutionPayloadHeader,BlindedBeaconBlockBody,BlindedBeaconBlock,RegisterValidatorRequestMessage,BuilderBid,SignedBuilderBid
-
 .PHONY: test-coverage
 test-coverage:
 	go test -race -v -covermode=atomic -coverprofile=coverage.out ./...
@@ -55,17 +50,9 @@ cover-html:
 	go tool cover -html=coverage.out
 	unlink coverage.out
 
-.PHONY: run
-run:
-	./mev-boost
-
 .PHONY: run-boost-with-relay
 run-boost-with-relay:
 	./mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545
-
-.PHONY: run-dev
-run-dev:
-	go run cmd/mev-boost/main.go
 
 .PHONY: run-mergemock-engine
 run-mergemock-engine:
@@ -88,12 +75,16 @@ build-for-docker:
 	GOOS=linux go build -ldflags "-X main.version=${VERSION}" -v -o mev-boost ./cmd/mev-boost
 
 .PHONY: docker-image
-docker-image:
+docker-image: clean build-for-docker
 	DOCKER_BUILDKIT=1 docker build . -t mev-boost
 	docker tag mev-boost:latest ${DOCKER_REPO}:${VERSION}
 	docker tag mev-boost:latest ${DOCKER_REPO}:latest
 
 .PHONY: docker-push
-docker-push:
+docker-push: docker-image
 	docker push ${DOCKER_REPO}:${VERSION}
 	docker push ${DOCKER_REPO}:latest
+
+.PHONY: clean
+clean:
+	rm -rf mev-boost

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build-for-docker:
 	GOOS=linux go build -ldflags "-X main.version=${VERSION}" -v -o mev-boost ./cmd/mev-boost
 
 .PHONY: docker-image
-docker-image: clean build-for-docker
+docker-image: build-for-docker
 	DOCKER_BUILDKIT=1 docker build . -t mev-boost
 	docker tag mev-boost:latest ${DOCKER_REPO}:${VERSION}
 	docker tag mev-boost:latest ${DOCKER_REPO}:latest
@@ -87,4 +87,4 @@ docker-push: docker-image
 
 .PHONY: clean
 clean:
-	rm -rf mev-boost
+	git clean -fdx

--- a/Makefile
+++ b/Makefile
@@ -4,73 +4,96 @@ MERGEMOCK_BIN=./mergemock
 VERSION ?= $(shell git describe --tags --always --dirty="-dev")
 DOCKER_REPO := flashbots/mev-boost
 
+.PHONY: all
+all: build
+
+.PHONY: v
 v:
 	@echo "${VERSION}"
 
+.PHONY: build
 build:
 	go build -ldflags "-X main.version=${VERSION}" -v -o mev-boost ./cmd/mev-boost
 
+.PHONY: build-testcli
 build-testcli:
 	go build -ldflags "-X main.version=${VERSION}" -v -o test-cli ./cmd/test-cli
 
+.PHONY: test
 test:
 	go test ./...
 
+.PHONY: test-race
 test-race:
 	go test -race ./...
 
+.PHONY: lint
 lint:
 	revive -set_exit_status ./...
 	go vet ./...
 	staticcheck ./...
 
+.PHONY: generate-ssz
 generate-ssz:
 	rm -f types/builder_encoding.go
 	sszgen --path types --include ../go-ethereum/common/hexutil --objs Eth1Data,BeaconBlockHeader,SignedBeaconBlockHeader,ProposerSlashing,Checkpoint,AttestationData,IndexedAttestation,AttesterSlashing,Attestation,Deposit,VoluntaryExit,SyncAggregate,ExecutionPayloadHeader,VersionedExecutionPayloadHeader,BlindedBeaconBlockBody,BlindedBeaconBlock,RegisterValidatorRequestMessage,BuilderBid,SignedBuilderBid
 
+.PHONY: test-coverage
 test-coverage:
 	go test -race -v -covermode=atomic -coverprofile=coverage.out ./...
 	go tool cover -func coverage.out
 
+.PHONY: cover
 cover:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -func coverage.out
 	unlink coverage.out
 
+.PHONY: cover-html
 cover-html:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 	unlink coverage.out
 
+.PHONY: run
 run:
 	./mev-boost
 
+.PHONY: run-boost-with-relay
 run-boost-with-relay:
 	./mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545
 
+.PHONY: run-dev
 run-dev:
 	go run cmd/mev-boost/main.go
 
+.PHONY: run-mergemock-engine
 run-mergemock-engine:
 	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) engine --listen-addr 127.0.0.1:8551
 
+.PHONY: run-mergemock-consensus
 run-mergemock-consensus:
 	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) consensus --slot-time=4s --engine http://127.0.0.1:8551 --builder http://127.0.0.1:18550 --slot-bound 10
 
+.PHONY: run-mergemock-relay
 run-mergemock-relay:
 	cd $(MERGEMOCK_DIR) && $(MERGEMOCK_BIN) relay --listen-addr 127.0.0.1:28545 --secret-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52
 
+.PHONY: run-mergemock-integration
 run-mergemock-integration: build
 	make -j3 run-boost-with-relay run-mergemock-consensus run-mergemock-relay
 
+.PHONY: build-for-docker
 build-for-docker:
 	GOOS=linux go build -ldflags "-X main.version=${VERSION}" -v -o mev-boost ./cmd/mev-boost
 
+.PHONY: docker-image
 docker-image:
 	DOCKER_BUILDKIT=1 docker build . -t mev-boost
 	docker tag mev-boost:latest ${DOCKER_REPO}:${VERSION}
 	docker tag mev-boost:latest ${DOCKER_REPO}:latest
 
+.PHONY: docker-push
 docker-push:
 	docker push ${DOCKER_REPO}:${VERSION}
 	docker push ${DOCKER_REPO}:latest


### PR DESCRIPTION
## 📝 Summary

* Add `all` and `clean` targets.
  * I'm sure I'm not the only one that's tried just running `make` to build things.
  * Using `git clean -fdx` instead of manually specifying files as we already depend on `git` for the version.
* Set fake targets (happens to be all of them) as phony (see reference).
  * Not really that important, but I think it's good practice.
* Delete `run` and `run-dev` rules. I don't think these make sense anymore.
  * `mev-boost` has required options (network) now.
* Delete the `generate-ssz` rule. This has been moved to `go-boost-utils` (see reference).
  * Took me a few minutes to realize that the `types` directory moved repos.
* Set dependencies for docker rules. Should be able to just do `docker-push`.
  * Didn't actually test this part, so please double-check.

## ⛱ Motivation and Context

I like Makefiles and I wanted to clean things up a bit.

## 📚 References

* https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
* https://github.com/flashbots/go-boost-utils/blob/417a64679a5d4a2c12b64ff7ee918243d4ab34eb/Makefile#L23-L25

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
