### PR TITLE
Handle unhandled errors

### DIFF
--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -190,7 +190,9 @@ func main() {
 	generateCommand.StringVar(&validatorFeeRecipient, "feeRecipient", envValidatorFeeRecipient, "FeeRecipient to register the validator with")
 
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s [generate|register|getHeader|getPayload]:\n", os.Args[0])
+		if _, err := fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s [generate|register|getHeader|getPayload]:\n", os.Args[0]); err != nil {
+			log.Fatal(err)
+		}
 		flag.PrintDefaults()
 	}
 
@@ -201,24 +203,32 @@ func main() {
 
 	switch os.Args[1] {
 	case "generate":
-		generateCommand.Parse(os.Args[2:])
+		if err := generateCommand.Parse(os.Args[2:]); err != nil {
+			log.Fatal(err)
+		}
 		doGenerateValidator(validatorDataFile, gasLimit, validatorFeeRecipient)
 	case "register":
-		registerCommand.Parse(os.Args[2:])
+		if err := registerCommand.Parse(os.Args[2:]); err != nil {
+			log.Fatal(err)
+		}
 		builderSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")
 		}
 		doRegisterValidator(mustLoadValidator(validatorDataFile), boostEndpoint, builderSigningDomain)
 	case "getHeader":
-		getHeaderCommand.Parse(os.Args[2:])
+		if err := getHeaderCommand.Parse(os.Args[2:]); err != nil {
+			log.Fatal(err)
+		}
 		builderSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")
 		}
 		doGetHeader(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint, builderSigningDomain)
 	case "getPayload":
-		getPayloadCommand.Parse(os.Args[2:])
+		if err := getPayloadCommand.Parse(os.Args[2:]); err != nil {
+			log.Fatal(err)
+		}
 		builderSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")

--- a/cmd/test-cli/requests.go
+++ b/cmd/test-cli/requests.go
@@ -42,7 +42,11 @@ func sendJSONRequest(endpoint string, payload any, dst any) error {
 		fetchLog.WithError(err).Error("could not send request")
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			fetchLog.WithError(err).Error("could not close body")
+		}
+	}()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	fetchLog.WithField("bodyBytes", string(bodyBytes)).Info("got response")


### PR DESCRIPTION
## 📝 Summary

Handle unhandled errors on everything except for mocks.

## ⛱ Motivation and Context

It's a good idea to handle the unhandled errors even though they are part of start-ups. Good practice; they showed up as warnings in my IDE.


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
