### PR TITLE
Default MaxHeaderSize to 4kb

### DIFF
--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -28,6 +28,7 @@ var (
 	defaultRelayTimeoutMs     = getEnvInt("RELAY_TIMEOUT_MS", 2000) // timeout for all the requests to the relay
 	defaultRelayCheck         = os.Getenv("RELAY_STARTUP_CHECK") != ""
 	defaultGenesisForkVersion = getEnv("GENESIS_FORK_VERSION", "")
+	defaultMaxHeaderBytes     = getEnvInt("MAX_HEADER_BYTES", 4000) // max header byte size for requests for dos prevention
 
 	// cli flags
 	logJSON  = flag.Bool("json", defaultLogJSON, "log in JSON format instead of text")
@@ -37,6 +38,7 @@ var (
 	relayURLs      = flag.String("relays", "", "relay urls - single entry or comma-separated list (scheme://pubkey@host)")
 	relayTimeoutMs = flag.Int("request-timeout", defaultRelayTimeoutMs, "timeout for requests to a relay [ms]")
 	relayCheck     = flag.Bool("relay-check", defaultRelayCheck, "check relay status on startup and on the status API call")
+	maxHeaderBytes = flag.Int("max-header-bytes", defaultMaxHeaderBytes, "max byte size of the header")
 
 	// helpers
 	useGenesisForkVersionMainnet = flag.Bool("mainnet", false, "use Mainnet genesis fork version 0x00000000 (for signature validation)")
@@ -102,6 +104,7 @@ func main() {
 		GenesisForkVersionHex: genesisForkVersionHex,
 		RelayRequestTimeout:   relayTimeout,
 		RelayCheck:            *relayCheck,
+		MaxHeaderBytes:        *maxHeaderBytes,
 	}
 	server, err := server.NewBoostService(opts)
 	if err != nil {

--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -28,7 +28,7 @@ var (
 	defaultRelayTimeoutMs     = getEnvInt("RELAY_TIMEOUT_MS", 2000) // timeout for all the requests to the relay
 	defaultRelayCheck         = os.Getenv("RELAY_STARTUP_CHECK") != ""
 	defaultGenesisForkVersion = getEnv("GENESIS_FORK_VERSION", "")
-	defaultMaxHeaderBytes     = getEnvInt("MAX_HEADER_BYTES", 4000) // max header byte size for requests for dos prevention
+	maxHeaderBytes            = getEnvInt("MAX_HEADER_BYTES", 4000) // max header byte size for requests for dos prevention
 
 	// cli flags
 	logJSON  = flag.Bool("json", defaultLogJSON, "log in JSON format instead of text")
@@ -38,7 +38,6 @@ var (
 	relayURLs      = flag.String("relays", "", "relay urls - single entry or comma-separated list (scheme://pubkey@host)")
 	relayTimeoutMs = flag.Int("request-timeout", defaultRelayTimeoutMs, "timeout for requests to a relay [ms]")
 	relayCheck     = flag.Bool("relay-check", defaultRelayCheck, "check relay status on startup and on the status API call")
-	maxHeaderBytes = flag.Int("max-header-bytes", defaultMaxHeaderBytes, "max byte size of the header")
 
 	// helpers
 	useGenesisForkVersionMainnet = flag.Bool("mainnet", false, "use Mainnet genesis fork version 0x00000000 (for signature validation)")
@@ -104,7 +103,7 @@ func main() {
 		GenesisForkVersionHex: genesisForkVersionHex,
 		RelayRequestTimeout:   relayTimeout,
 		RelayCheck:            *relayCheck,
-		MaxHeaderBytes:        *maxHeaderBytes,
+		MaxHeaderBytes:        maxHeaderBytes,
 	}
 	server, err := server.NewBoostService(opts)
 	if err != nil {

--- a/server/service.go
+++ b/server/service.go
@@ -43,6 +43,7 @@ type BoostServiceOpts struct {
 	GenesisForkVersionHex string
 	RelayRequestTimeout   time.Duration
 	RelayCheck            bool
+	MaxHeaderBytes        int
 }
 
 // BoostService TODO
@@ -52,6 +53,8 @@ type BoostService struct {
 	log        *logrus.Entry
 	srv        *http.Server
 	relayCheck bool
+
+	maxHeaderBytes int
 
 	builderSigningDomain types.Domain
 	httpClient           http.Client
@@ -69,10 +72,11 @@ func NewBoostService(opts BoostServiceOpts) (*BoostService, error) {
 	}
 
 	return &BoostService{
-		listenAddr: opts.ListenAddr,
-		relays:     opts.Relays,
-		log:        opts.Log.WithField("module", "service"),
-		relayCheck: opts.RelayCheck,
+		listenAddr:     opts.ListenAddr,
+		relays:         opts.Relays,
+		log:            opts.Log.WithField("module", "service"),
+		relayCheck:     opts.RelayCheck,
+		maxHeaderBytes: opts.MaxHeaderBytes,
 
 		builderSigningDomain: builderSigningDomain,
 		httpClient: http.Client{
@@ -131,6 +135,7 @@ func (m *BoostService) StartHTTPServer() error {
 		ReadHeaderTimeout: 0,
 		WriteTimeout:      0,
 		IdleTimeout:       0,
+		MaxHeaderBytes:    m.maxHeaderBytes,
 	}
 
 	err := m.srv.ListenAndServe()

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -481,4 +481,16 @@ func TestCheckRelays(t *testing.T) {
 
 		require.Equal(t, false, status)
 	})
+
+	t.Run("Should not follow redirects", func(t *testing.T) {
+		backend := newTestBackend(t, 1, time.Second)
+		redirectAddress := backend.relays[0].Server.URL
+		backend.relays[0].Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirectAddress, http.StatusTemporaryRedirect)
+		}))
+
+		backend.boost.relays[0].Address = backend.relays[0].Server.URL
+		status := backend.boost.CheckRelays()
+		require.Equal(t, false, status)
+	})
 }


### PR DESCRIPTION
## 📝 Summary

Add flag for boost to configure max header size, defaulting to 4kb.

## ⛱ Motivation and Context

This is to prevent DoS attacks by preventing attackers sending oversized headers to mev-boost. 

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `make run-mergemock-integration`
* [ ] `go mod tidy`
