### PR TITLE
Remove redundant signature check

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -360,11 +360,6 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	if len(payload.Signature) != 96 {
-		m.respondError(w, http.StatusBadRequest, errInvalidSignature.Error())
-		return
-	}
-
 	result := new(types.GetPayloadResponse)
 	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
 	defer requestCtxCancel()


### PR DESCRIPTION
Payload's signature is already default at 96 bytes due to `Signature` type, `handleGetPayload`'s signature length check is redundant and can be removed

```go
package types

type Signature [96]byte
```