### PR TITLE
Disallow indefinite http client timeout

### DIFF
--- a/cmd/mev-boost/main.go
+++ b/cmd/mev-boost/main.go
@@ -98,6 +98,9 @@ func main() {
 	log.WithField("relays", relays).Infof("using %d relays", len(relays))
 
 	relayTimeout := time.Duration(*relayTimeoutMs) * time.Millisecond
+	if relayTimeout <= 0 {
+		log.Fatal("Please specify a relay timeout greater than 0")
+	}
 
 	opts := server.BoostServiceOpts{
 		Log:                   log,


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Ensure that timeout for relay requests to be greater than 0.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
0 and negative timeout values result in no timeout, which a malicious relay can potentially block execution, especially in the `handleGetHeader` function.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
