### PR TITLE
Send version in User-Agent header

### DIFF
--- a/cmd/test-cli/beacon.go
+++ b/cmd/test-cli/beacon.go
@@ -53,7 +53,7 @@ type partialSignedBeaconBlock struct {
 
 func getCurrentBeaconBlock(beaconEndpoint string) (beaconBlockData, error) {
 	var blockResp partialSignedBeaconBlock
-	_, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, beaconEndpoint+"/eth/v2/beacon/blocks/head", nil, &blockResp)
+	_, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, beaconEndpoint+"/eth/v2/beacon/blocks/head", "test-cli/beacon", nil, &blockResp)
 	if err != nil {
 		return beaconBlockData{}, err
 	}

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -31,7 +31,7 @@ func doRegisterValidator(v validatorPrivateData, boostEndpoint string, builderSi
 	if err != nil {
 		log.WithError(err).Fatal("Could not prepare registration message")
 	}
-	_, err = server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodPost, boostEndpoint+"/eth/v1/builder/validators", message, nil)
+	_, err = server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodPost, boostEndpoint+"/eth/v1/builder/validators", "test-cli", message, nil)
 
 	if err != nil {
 		log.WithError(err).Fatal("Validator registration not successful")
@@ -68,7 +68,7 @@ func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon
 	uri := fmt.Sprintf("%s/eth/v1/builder/header/%d/%s/%s", boostEndpoint, currentBlock.Slot+1, currentBlockHash, v.Pk.String())
 
 	var getHeaderResp boostTypes.GetHeaderResponse
-	if _, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, uri, nil, &getHeaderResp); err != nil {
+	if _, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, uri, "test-cli", nil, &getHeaderResp); err != nil {
 		log.WithError(err).WithField("currentBlockHash", currentBlockHash).Fatal("Could not get header")
 	}
 
@@ -120,7 +120,7 @@ func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beaco
 		Signature: signature,
 	}
 	var respPayload boostTypes.GetPayloadResponse
-	if _, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodPost, boostEndpoint+"/eth/v1/builder/blinded_blocks", payload, &respPayload); err != nil {
+	if _, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodPost, boostEndpoint+"/eth/v1/builder/blinded_blocks", "test-cli", payload, &respPayload); err != nil {
 		log.WithError(err).Fatal("could not get payload")
 	}
 

--- a/server/relay_entry.go
+++ b/server/relay_entry.go
@@ -44,10 +44,6 @@ func NewRelayEntry(relayURL string) (entry RelayEntry, err error) {
 		return entry, ErrMissingRelayPubkey
 	}
 
-	q := entry.URL.Query()
-	q.Set("boost", Version)
-	entry.URL.RawQuery = q.Encode()
-
 	err = entry.PublicKey.UnmarshalText([]byte(entry.URL.User.Username()))
 	return entry, err
 }

--- a/server/relay_entry_test.go
+++ b/server/relay_entry_test.go
@@ -26,9 +26,9 @@ func TestParseRelaysURLs(t *testing.T) {
 			name:     "Relay URL with protocol scheme",
 			relayURL: fmt.Sprintf("http://%s@foo.com", publicKey.String()),
 
-			expectedURI:       "http://foo.com?boost=dev",
+			expectedURI:       "http://foo.com",
 			expectedPublicKey: publicKey.String(),
-			expectedURL:       fmt.Sprintf("http://%s@foo.com?boost=dev", publicKey.String()),
+			expectedURL:       fmt.Sprintf("http://%s@foo.com", publicKey.String()),
 		},
 		{
 			name:     "Relay URL without protocol scheme, without public key",
@@ -40,33 +40,33 @@ func TestParseRelaysURLs(t *testing.T) {
 			name:     "Relay URL without protocol scheme and with public key",
 			relayURL: publicKey.String() + "@foo.com",
 
-			expectedURI:       "http://foo.com?boost=dev",
+			expectedURI:       "http://foo.com",
 			expectedPublicKey: publicKey.String(),
-			expectedURL:       "http://" + publicKey.String() + "@foo.com?boost=dev",
+			expectedURL:       "http://" + publicKey.String() + "@foo.com",
 		},
 		{
 			name:     "Relay URL with public key host and port",
 			relayURL: publicKey.String() + "@foo.com:9999",
 
-			expectedURI:       "http://foo.com:9999?boost=dev",
+			expectedURI:       "http://foo.com:9999",
 			expectedPublicKey: publicKey.String(),
-			expectedURL:       "http://" + publicKey.String() + "@foo.com:9999?boost=dev",
+			expectedURL:       "http://" + publicKey.String() + "@foo.com:9999",
 		},
 		{
 			name:     "Relay URL with IP and port",
 			relayURL: publicKey.String() + "@12.345.678:9999",
 
-			expectedURI:       "http://12.345.678:9999?boost=dev",
+			expectedURI:       "http://12.345.678:9999",
 			expectedPublicKey: publicKey.String(),
-			expectedURL:       "http://" + publicKey.String() + "@12.345.678:9999?boost=dev",
+			expectedURL:       "http://" + publicKey.String() + "@12.345.678:9999",
 		},
 		{
 			name:     "Relay URL with https IP and port",
 			relayURL: "https://" + publicKey.String() + "@12.345.678:9999",
 
-			expectedURI:       "https://12.345.678:9999?boost=dev",
+			expectedURI:       "https://12.345.678:9999",
 			expectedPublicKey: publicKey.String(),
-			expectedURL:       "https://" + publicKey.String() + "@12.345.678:9999?boost=dev",
+			expectedURL:       "https://" + publicKey.String() + "@12.345.678:9999",
 		},
 		{
 			name:     "Invalid relay public key",
@@ -78,9 +78,9 @@ func TestParseRelaysURLs(t *testing.T) {
 			name:     "Relay URL with query arg",
 			relayURL: fmt.Sprintf("http://%s@foo.com?id=foo&bar=1", publicKey.String()),
 
-			expectedURI:       "http://foo.com?bar=1&boost=dev&id=foo",
+			expectedURI:       "http://foo.com?id=foo&bar=1",
 			expectedPublicKey: publicKey.String(),
-			expectedURL:       fmt.Sprintf("http://%s@foo.com?bar=1&boost=dev&id=foo", publicKey.String()),
+			expectedURL:       fmt.Sprintf("http://%s@foo.com?id=foo&bar=1", publicKey.String()),
 		},
 	}
 

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -129,7 +129,7 @@ func TestWebserverMaxHeaderSize(t *testing.T) {
 	}()
 	time.Sleep(time.Millisecond * 100)
 	path := "http://" + addr + "?" + strings.Repeat("abc", 4000) // path with characters of size over 4kb
-	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, path, nil, nil)
+	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, path, "test", nil, nil)
 	require.Error(t, err)
 	require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, code)
 	backend.boost.srv.Close()

--- a/server/utils.go
+++ b/server/utils.go
@@ -8,14 +8,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/flashbots/go-boost-utils/types"
 )
 
+// UserAgent is a custom string type to avoid confusing url + userAgent parameters in SendHTTPRequest
+type UserAgent string
+
 // SendHTTPRequest - prepare and send HTTP request, marshaling the payload if any, and decoding the response if dst is set
-func SendHTTPRequest(ctx context.Context, client http.Client, method, url string, payload any, dst any) (code int, err error) {
+func SendHTTPRequest(ctx context.Context, client http.Client, method, url string, userAgent UserAgent, payload any, dst any) (code int, err error) {
 	var req *http.Request
 
 	if payload == nil {
@@ -26,12 +30,18 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 			return 0, fmt.Errorf("could not marshal request: %w", err2)
 		}
 		req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payloadBytes))
+
+		// Set content-type
+		req.Header.Add("Content-Type", "application/json")
 	}
 	if err != nil {
 		return 0, fmt.Errorf("could not prepare request: %w", err)
 	}
 
-	req.Header.Add("Content-Type", "application/json")
+	// Set user agent
+	req.Header.Set("User-Agent", strings.TrimSpace(fmt.Sprintf("mev-boost/%s %s", Version, userAgent)))
+
+	// Execute request
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 func TestMakePostRequest(t *testing.T) {
 	// Test errors
 	var x chan bool
-	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, "", x, nil)
+	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, "", "test", x, nil)
 	require.Error(t, err)
 	require.Equal(t, 0, code)
 }
@@ -27,4 +28,31 @@ func TestDecodeJSON(t *testing.T) {
 	err := DecodeJSON(payload, &x)
 	require.Error(t, err)
 	require.Equal(t, "json: unknown field \"c\"", err.Error())
+}
+
+func TestSendHTTPRequestUserAgent(t *testing.T) {
+	done := make(chan bool, 1)
+
+	// Test with custom UA
+	customUA := "test-user-agent"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "mev-boost/dev "+customUA, r.Header.Get("User-Agent"))
+		done <- true
+	}))
+	defer ts.Close()
+	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, ts.URL, UserAgent(customUA), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, code)
+	<-done
+
+	// Test without custom UA
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "mev-boost/dev", r.Header.Get("User-Agent"))
+		done <- true
+	}))
+	defer ts.Close()
+	code, err = SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, ts.URL, "", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, code)
+	<-done
 }


### PR DESCRIPTION
## 📝 Summary

Send mev-boost version and calling user-agent in request `User-Agent` header (instead of query arg).

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
