### PR TITLE
readme update, remove goerli sf5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ This project is part of the Flashbots research towards proposer/builder separati
 See also:
 
 * [Builder API specification](https://ethereum.github.io/builder-specs)
+* [Relay API documentation](https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5)
 * [mev-boost Docker image](https://hub.docker.com/r/flashbots/mev-boost)
 * [Integration docs (mev-boost wiki)](https://github.com/flashbots/mev-boost/wiki)
+* [boost.flashbots.net](https://boost.flashbots.net)
 
 ---
 
@@ -91,14 +93,6 @@ docker run flashbots/mev-boost -help
 # Usage
 
 First, install and run one of the [supported consensus clients](#consensus-clients-implementation-status).
-
-### Goerli Shadow Fork 5
-
-Run mev-boost pointed at our [Goerli Shadow Fork 5 Relay](https://builder-relay-goerli-sf5.flashbots.net):
-
-```bash
-./mev-boost -goerli-shadow-fork-5 -relays https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@builder-relay-goerli-sf5.flashbots.net
-```
 
 ### Ropsten testnet
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -14,11 +14,10 @@ import (
 )
 
 const (
-	genesisForkVersionMainnet   = "0x00000000"
-	genesisForkVersionKiln      = "0x70000069" // https://github.com/eth-clients/merge-testnets/blob/main/kiln/config.yaml#L10
-	genesisForkVersionRopsten   = "0x80000069"
-	genesisForkVersionSepolia   = "0x90000069"
-	genesisForkVersionGoerliSF5 = "0x13001034" // https://github.com/eth-clients/merge-testnets/blob/main/goerli-shadow-fork-5/config.yaml#L11
+	genesisForkVersionMainnet = "0x00000000"
+	genesisForkVersionKiln    = "0x70000069" // https://github.com/eth-clients/merge-testnets/blob/main/kiln/config.yaml#L10
+	genesisForkVersionRopsten = "0x80000069"
+	genesisForkVersionSepolia = "0x90000069"
 )
 
 var (
@@ -41,12 +40,11 @@ var (
 	relayCheck     = flag.Bool("relay-check", defaultRelayCheck, "check relay status on startup and on the status API call")
 
 	// helpers
-	useGenesisForkVersionMainnet   = flag.Bool("mainnet", false, "use Mainnet")
-	useGenesisForkVersionKiln      = flag.Bool("kiln", false, "use Kiln")
-	useGenesisForkVersionRopsten   = flag.Bool("ropsten", false, "use Ropsten")
-	useGenesisForkVersionSepolia   = flag.Bool("sepolia", false, "use Sepolia")
-	useGenesisForkVersionGoerliSF5 = flag.Bool("goerli-shadow-fork-5", false, "use Goerli shadow fork")
-	useCustomGenesisForkVersion    = flag.String("genesis-fork-version", defaultGenesisForkVersion, "use a custom genesis fork version")
+	useGenesisForkVersionMainnet = flag.Bool("mainnet", false, "use Mainnet")
+	useGenesisForkVersionKiln    = flag.Bool("kiln", false, "use Kiln")
+	useGenesisForkVersionRopsten = flag.Bool("ropsten", false, "use Ropsten")
+	useGenesisForkVersionSepolia = flag.Bool("sepolia", false, "use Sepolia")
+	useCustomGenesisForkVersion  = flag.String("genesis-fork-version", defaultGenesisForkVersion, "use a custom genesis fork version")
 )
 
 var log = logrus.WithField("module", "cli")
@@ -92,8 +90,6 @@ func Main() {
 		genesisForkVersionHex = genesisForkVersionRopsten
 	} else if *useGenesisForkVersionSepolia {
 		genesisForkVersionHex = genesisForkVersionSepolia
-	} else if *useGenesisForkVersionGoerliSF5 {
-		genesisForkVersionHex = genesisForkVersionGoerliSF5
 	} else {
 		flag.Usage()
 		log.Fatal("Please specify a genesis fork version (eg. -mainnet / -kiln / -ropsten / -sepolia / -goerli-shadow-fork-5 / -genesis-fork-version flags)")


### PR DESCRIPTION
## 📝 Summary

* readme update
* remove goerli sf5 (deprecated with today, all tests successful)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
