### PR TITLE
if no payload is received, log which relays sent the corresponding bid

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -102,9 +102,10 @@ func DecodeJSON(r io.Reader, dst any) error {
 
 // bidResp are entries in the bids cache
 type bidResp struct {
-	t        time.Time
-	response types.GetHeaderResponse
-	relay    string
+	t         time.Time
+	response  types.GetHeaderResponse
+	blockHash string
+	relays    []string
 }
 
 // bidRespKey is used as key for the bids cache

--- a/server/utils.go
+++ b/server/utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -97,4 +98,17 @@ func DecodeJSON(r io.Reader, dst any) error {
 		return err
 	}
 	return nil
+}
+
+// bidResp are entries in the bids cache
+type bidResp struct {
+	t        time.Time
+	response types.GetHeaderResponse
+	relay    string
+}
+
+// bidRespKey is used as key for the bids cache
+type bidRespKey struct {
+	slot      uint64
+	blockHash string
 }


### PR DESCRIPTION
## 📝 Summary

When sending a signedBlindedBeaconBlock to all the relays, and no payload is received, mev-boost should log which relay the bid was coming from, to know which relay was causing the problem. For this, we need to remember the bid, to recover it in getPayload.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
