### PR TITLE
Adjust mergemock integration test cleanup

### DIFF
--- a/scripts/run_mergemock_integration.sh
+++ b/scripts/run_mergemock_integration.sh
@@ -12,21 +12,12 @@ MERGEMOCK_BIN=${MERGEMOCK_BIN:-./mergemock}
 #
 # This function will ensure there are no lingering processes afterwards.
 #
-cleanup() {
-  for pid in $BOOST_WITH_RELAY_PID $MERGEMOCK_RELAY_PID $MERGEMOCK_CONSENSUS_PID; do
-    if ps -p $pid &>/dev/null; then
-      disown $pid
-      kill -9 $pid &>/dev/null
-    fi
-  done
-}
-trap cleanup exit
+trap 'kill -9 $(jobs -p)' exit
 
 #
 # Start mev-boost.
 #
 $PROJECT_DIR/mev-boost -mainnet -relays http://0x821961b64d99b997c934c22b4fd6109790acf00f7969322c4e9dbf1ca278c333148284c01c5ef551a1536ddd14b178b9@127.0.0.1:28545 &
-BOOST_WITH_RELAY_PID=$!
 echo "Waiting for mev-boost to become available..."
 while ! nc -z localhost 18550; do
   sleep 0.1
@@ -37,7 +28,6 @@ done
 #
 pushd $MERGEMOCK_DIR >/dev/null
 $MERGEMOCK_BIN relay --listen-addr 127.0.0.1:28545 --secret-key 1e64a14cb06073c2d7c8b0b891e5dc3dc719b86e5bf4c131ddbaa115f09f8f52 &
-MERGEMOCK_RELAY_PID=$!
 echo "Waiting for relay to become available..."
 while ! nc -z localhost 28545; do
   sleep 0.1


### PR DESCRIPTION
## 📝 Summary

Current implementation won't work if there's a problem with any of the intermediate PID values, as the for loop won't be ran.

## ⛱ Motivation and Context

Killing based on jobs -p should work in most cases.

## 📚 References

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [x] `make run-mergemock-integration`
* [ ] `go mod tidy`
