### PR TITLE
getHeader: verify that pubkey in message is the relay-key we trust

### DIFF
--- a/server/mock_relay_test.go
+++ b/server/mock_relay_test.go
@@ -2,19 +2,16 @@ package server
 
 import (
 	"bytes"
-	"github.com/flashbots/go-boost-utils/bls"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_mockRelay(t *testing.T) {
 	t.Run("bad payload", func(t *testing.T) {
-		privateKey, _, err := bls.GenerateNewKeypair()
-		require.NoError(t, err)
-
-		relay := newMockRelay(t, privateKey)
+		relay := newMockRelay(t)
 		req, err := http.NewRequest("POST", pathRegisterValidator, bytes.NewReader([]byte("123")))
 		require.NoError(t, err)
 		rr := httptest.NewRecorder()

--- a/server/service.go
+++ b/server/service.go
@@ -326,6 +326,11 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 				"value":       responsePayload.Data.Message.Value.String(),
 			})
 
+			if relay.PublicKey != responsePayload.Data.Message.Pubkey {
+				log.Errorf("bid pubkey mismatch. expected: %s - got: %s", relay.PublicKey.String(), responsePayload.Data.Message.Pubkey.String())
+				return
+			}
+
 			// Verify the relay signature in the relay response
 			ok, err := types.VerifySignature(responsePayload.Data.Message, m.builderSigningDomain, relay.PublicKey[:], responsePayload.Data.Signature[:])
 			if err != nil {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flashbots/go-boost-utils/bls"
-
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/require"
 )
@@ -32,12 +30,8 @@ func newTestBackend(t *testing.T, numRelays int, relayTimeout time.Duration) *te
 
 	relayEntries := make([]RelayEntry, numRelays)
 	for i := 0; i < numRelays; i++ {
-		// Generate private key for relay
-		blsPrivateKey, _, err := bls.GenerateNewKeypair()
-		require.NoError(t, err)
-
 		// Create a mock relay
-		backend.relays[i] = newMockRelay(t, blsPrivateKey)
+		backend.relays[i] = newMockRelay(t)
 		relayEntries[i] = backend.relays[i].RelayEntry
 	}
 


### PR DESCRIPTION
## 📝 Summary

Verifies that the public key in the bid matches the pre-configured relay public key. Might be necessary to avoid issues with BLS signatures.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
