### PR TITLE
Parse slot/gas as uint64 in test code to prevent downcasting

### DIFF
--- a/cmd/test-cli/beacon.go
+++ b/cmd/test-cli/beacon.go
@@ -58,12 +58,12 @@ func getCurrentBeaconBlock(beaconEndpoint string) (beaconBlockData, error) {
 		return beaconBlockData{}, err
 	}
 
-	slot, err := strconv.Atoi(blockResp.Data.Message.Slot)
+	slot, err := strconv.ParseUint(blockResp.Data.Message.Slot, 10, 64)
 	if err != nil {
 		return beaconBlockData{}, err
 	}
 
-	return beaconBlockData{Slot: uint64(slot), BlockHash: blockResp.Data.Message.Body.ExecutionPayload.BlockHash}, err
+	return beaconBlockData{Slot: slot, BlockHash: blockResp.Data.Message.Body.ExecutionPayload.BlockHash}, err
 }
 
 // MergemockBeacon - fake beacon for use with mergemock relay's engine

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -179,11 +179,11 @@ func main() {
 
 	var gasLimit uint64
 	envGasLimitStr := getEnv("VALIDATOR_GAS_LIMIT", "30000000")
-	envGasLimit, err := strconv.Atoi(envGasLimitStr)
+	envGasLimit, err := strconv.ParseUint(envGasLimitStr, 10, 64)
 	if err != nil {
 		log.WithError(err).Fatal("invalid gas limit specified")
 	}
-	generateCommand.Uint64Var(&gasLimit, "gas-limit", uint64(envGasLimit), "Gas limit to register the validator with")
+	generateCommand.Uint64Var(&gasLimit, "gas-limit", envGasLimit, "Gas limit to register the validator with")
 
 	var validatorFeeRecipient string
 	envValidatorFeeRecipient := getEnv("VALIDATOR_FEE_RECIPIENT", "0x0000000000000000000000000000000000000000")


### PR DESCRIPTION
## 📝 Summary

* Parse `slot` and `gas` with `ParseUint` instead of `Atoi`.

## ⛱ Motivation and Context

The values were being parsed as signed integers and converted to unsigned 64-bit integers.

This was identified with Semgrep & the `string-to-int-signedness-cast` rule.

<img width="899" alt="image" src="https://user-images.githubusercontent.com/95511699/185417248-f46cd196-dda6-483e-9dbb-6a0343c52d3b.png">

## 📚 References

* https://semgrep.dev/
* https://semgrep.dev/r?q=trailofbits.go.string-to-int-signedness-cast.string-to-int-signedness-cast
* https://github.com/trailofbits/semgrep-rules/blob/main/go/string-to-int-signedness-cast.yml

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
