### PR TITLE
portable blst build in docker image

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -40,6 +40,16 @@ jobs:
           tags: flashbots/mev-boost:latest,flashbots/mev-boost:${{ steps.vars.outputs.tag }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Build and push portable
+        uses: docker/build-push-action@v3
+        env:
+          VERSION: ${{ steps.vars.outputs.tag }}
+          CGO_CFLAGS: "O -D__BLST_PORTABLE__"
+        with:
+          context: .
+          push: true
+          tags: flashbots/mev-boost:latest-portable,flashbots/mev-boost:${{ steps.vars.outputs.tag }}-portable
+          platforms: linux/amd64,linux/arm64
 
   github-release:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ v:
 build:
 	go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o mev-boost .
 
+.PHONY: build-portable
+build-portable:
+	CGO_CFLAGS=-"O -D__BLST_PORTABLE__" go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o mev-boost .
+
 .PHONY: build-testcli
 build-testcli:
 	go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o test-cli ./cmd/test-cli
@@ -54,6 +58,10 @@ run-mergemock-integration: build
 .PHONY: build-for-docker
 build-for-docker:
 	GOOS=linux go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o mev-boost .
+
+.PHONY: build-for-docker-portable
+build-for-docker-portable:
+	CGO_CFLAGS=-"O -D__BLST_PORTABLE__" GOOS=linux go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o mev-boost .
 
 .PHONY: docker-image
 docker-image:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ make build
 ./mev-boost -help
 ```
 
+If mev-boost crashes with [`"SIGILL: illegal instruction"`](https://github.com/flashbots/mev-boost/issues/256) then you need to create a portable build:
+
+```bash
+CGO_CFLAGS=-"O -D__BLST_PORTABLE__" go install github.com/flashbots/mev-boost@latest
+
+# or
+make build-portable
+```
+
 ## From Docker image
 
 We maintain a mev-boost Docker image at https://hub.docker.com/r/flashbots/mev-boost


### PR DESCRIPTION
## 📝 Summary

builds blst with portable flags

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
