### PR TITLE
feat: add dependabot support

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    reviewers:
+      - "metachris"


### PR DESCRIPTION
Signed-off-by: Luca Georges Francois <luca.georges-francois@kiln.fi>

## 📝 Summary

This PR enables dependabot to check new version of dependencies on a daily basis.
@metachris is set as the default reviewer for potential PRs by dependabot.

## ⛱ Motivation and Context

To avoid having to manually check for new versions of the project's dependencies.

## 📚 References

[Dependabot configuration available here.](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates)

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `make run-mergemock-integration`
* [ ] `go mod tidy`
