### PR TITLE
Fix test-cli README build command

### DIFF
--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -5,7 +5,7 @@ test-cli is a utility to run through all the proposer requests against mev-boost
 ## Build
 
 ```
-make build-cli
+make build-testcli
 ```
 
 ## Usage


### PR DESCRIPTION
## 📝 Summary

Update test-cli build command in README from `make build-cli` to `make build-testcli` as build-cli is no longer in the makefile.

## ⛱ Motivation and Context

Tried to build the test-cli to test locally and was unable to with current readme command

## 📚 References

n/a

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `make run-mergemock-integration`
* [x] `go mod tidy`
