### PR TITLE
getPayload: error if payload parts are missing

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -429,6 +429,11 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	if payload.Message == nil || payload.Message.Body == nil || payload.Message.Body.ExecutionPayloadHeader == nil {
+		m.respondError(w, http.StatusBadRequest, "missing parts of the payload")
+		return
+	}
+
 	log = log.WithField("blockHash", payload.Message.Body.ExecutionPayloadHeader.BlockHash.String())
 	var wg sync.WaitGroup
 	var mu sync.Mutex


### PR DESCRIPTION
## 📝 Summary

getPayload: additional checks for payload errors

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
