### PR TITLE
getHeader request timeout 950ms, allow setting timeouts individually for different requests

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -45,7 +45,7 @@ var (
 
 	relayTimeoutMsGetHeader  = flag.Int("request-timeout-getheader", defaultTimeoutMsGetHeader, "timeout for getHeader requests to the relay [ms]")
 	relayTimeoutMsGetPayload = flag.Int("request-timeout-getpayload", defaultTimeoutMsGetPayload, "timeout for getPayload requests to the relay [ms]")
-	relayTimeoutMsRegVal     = flag.Int("request-timeout-regval", defaultTimeoutMsRegisterValidator, "timeout for registraterValidator requests [ms]")
+	relayTimeoutMsRegVal     = flag.Int("request-timeout-regval", defaultTimeoutMsRegisterValidator, "timeout for registerValidator requests [ms]")
 
 	// helpers
 	useGenesisForkVersionMainnet = flag.Bool("mainnet", false, "use Mainnet")

--- a/cli/main.go
+++ b/cli/main.go
@@ -26,19 +26,26 @@ var (
 	defaultLogJSON            = os.Getenv("LOG_JSON") != ""
 	defaultLogLevel           = getEnv("LOG_LEVEL", "info")
 	defaultListenAddr         = getEnv("BOOST_LISTEN_ADDR", "localhost:18550")
-	defaultRelayTimeoutMs     = getEnvInt("RELAY_TIMEOUT_MS", 2000) // timeout for all the requests to the relay
 	defaultRelayCheck         = os.Getenv("RELAY_STARTUP_CHECK") != ""
 	defaultGenesisForkVersion = getEnv("GENESIS_FORK_VERSION", "")
+
+	// mev-boost relay request timeouts (see also https://github.com/flashbots/mev-boost/issues/287)
+	defaultTimeoutMsGetHeader         = getEnvInt("RELAY_TIMEOUT_MS_GETHEADER", 950)   // timeout for getHeader requests
+	defaultTimeoutMsGetPayload        = getEnvInt("RELAY_TIMEOUT_MS_GETPAYLOAD", 4000) // timeout for getPayload requests
+	defaultTimeoutMsRegisterValidator = getEnvInt("RELAY_TIMEOUT_MS_REGVAL", 3000)     // timeout for registerValidator requests
 
 	// cli flags
 	printVersion = flag.Bool("version", false, "only print version")
 	logJSON      = flag.Bool("json", defaultLogJSON, "log in JSON format instead of text")
 	logLevel     = flag.String("loglevel", defaultLogLevel, "minimum loglevel: trace, debug, info, warn/warning, error, fatal, panic")
 
-	listenAddr     = flag.String("addr", defaultListenAddr, "listen-address for mev-boost server")
-	relayURLs      = flag.String("relays", "", "relay urls - single entry or comma-separated list (scheme://pubkey@host)")
-	relayTimeoutMs = flag.Int("request-timeout", defaultRelayTimeoutMs, "timeout for requests to a relay [ms]")
-	relayCheck     = flag.Bool("relay-check", defaultRelayCheck, "check relay status on startup and on the status API call")
+	listenAddr = flag.String("addr", defaultListenAddr, "listen-address for mev-boost server")
+	relayURLs  = flag.String("relays", "", "relay urls - single entry or comma-separated list (scheme://pubkey@host)")
+	relayCheck = flag.Bool("relay-check", defaultRelayCheck, "check relay status on startup and on the status API call")
+
+	relayTimeoutMsGetHeader  = flag.Int("request-timeout-getheader", defaultTimeoutMsGetHeader, "timeout for getHeader requests to the relay [ms]")
+	relayTimeoutMsGetPayload = flag.Int("request-timeout-getpayload", defaultTimeoutMsGetPayload, "timeout for getPayload requests to the relay [ms]")
+	relayTimeoutMsRegVal     = flag.Int("request-timeout-regval", defaultTimeoutMsRegisterValidator, "timeout for registraterValidator requests [ms]")
 
 	// helpers
 	useGenesisForkVersionMainnet = flag.Bool("mainnet", false, "use Mainnet")
@@ -107,18 +114,15 @@ func Main() {
 	}
 	log.WithField("relays", relays).Infof("using %d relays", len(relays))
 
-	relayTimeout := time.Duration(*relayTimeoutMs) * time.Millisecond
-	if relayTimeout <= 0 {
-		log.Fatal("Please specify a relay timeout greater than 0")
-	}
-
 	opts := server.BoostServiceOpts{
-		Log:                   log,
-		ListenAddr:            *listenAddr,
-		Relays:                relays,
-		GenesisForkVersionHex: genesisForkVersionHex,
-		RelayRequestTimeout:   relayTimeout,
-		RelayCheck:            *relayCheck,
+		Log:                      log,
+		ListenAddr:               *listenAddr,
+		Relays:                   relays,
+		GenesisForkVersionHex:    genesisForkVersionHex,
+		RelayCheck:               *relayCheck,
+		RequestTimeoutGetHeader:  time.Duration(*relayTimeoutMsGetHeader) * time.Millisecond,
+		RequestTimeoutGetPayload: time.Duration(*relayTimeoutMsGetPayload) * time.Millisecond,
+		RequestTimeoutRegVal:     time.Duration(*relayTimeoutMsRegVal) * time.Millisecond,
 	}
 	server, err := server.NewBoostService(opts)
 	if err != nil {

--- a/server/service.go
+++ b/server/service.go
@@ -42,8 +42,11 @@ type BoostServiceOpts struct {
 	ListenAddr            string
 	Relays                []RelayEntry
 	GenesisForkVersionHex string
-	RelayRequestTimeout   time.Duration
 	RelayCheck            bool
+
+	RequestTimeoutGetHeader  time.Duration
+	RequestTimeoutGetPayload time.Duration
+	RequestTimeoutRegVal     time.Duration
 }
 
 // BoostService - the mev-boost service
@@ -55,7 +58,9 @@ type BoostService struct {
 	relayCheck bool
 
 	builderSigningDomain types.Domain
-	httpClient           http.Client
+	httpClientGetHeader  http.Client
+	httpClientGetPayload http.Client
+	httpClientRegVal     http.Client
 
 	bidsLock sync.Mutex
 	bids     map[bidRespKey]bidResp // keeping track of bids, to log the originating relay on withholding
@@ -80,11 +85,17 @@ func NewBoostService(opts BoostServiceOpts) (*BoostService, error) {
 		bids:       make(map[bidRespKey]bidResp),
 
 		builderSigningDomain: builderSigningDomain,
-		httpClient: http.Client{
-			Timeout: opts.RelayRequestTimeout,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
+		httpClientGetHeader: http.Client{
+			Timeout:       opts.RequestTimeoutGetHeader,
+			CheckRedirect: httpClientDisallowRedirects,
+		},
+		httpClientGetPayload: http.Client{
+			Timeout:       opts.RequestTimeoutGetPayload,
+			CheckRedirect: httpClientDisallowRedirects,
+		},
+		httpClientRegVal: http.Client{
+			Timeout:       opts.RequestTimeoutRegVal,
+			CheckRedirect: httpClientDisallowRedirects,
 		},
 	}, nil
 }
@@ -190,7 +201,7 @@ func (m *BoostService) handleStatus(w http.ResponseWriter, req *http.Request) {
 			log := m.log.WithField("url", url)
 			log.Debug("Checking relay status")
 
-			_, err := SendHTTPRequest(ctx, m.httpClient, http.MethodGet, url, ua, nil, nil)
+			_, err := SendHTTPRequest(ctx, m.httpClientGetHeader, http.MethodGet, url, ua, nil, nil)
 			if err != nil && ctx.Err() != context.Canceled {
 				log.WithError(err).Error("failed to retrieve relay status")
 				return
@@ -236,7 +247,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 			url := relay.GetURI(pathRegisterValidator)
 			log := log.WithField("url", url)
 
-			_, err := SendHTTPRequest(context.Background(), m.httpClient, http.MethodPost, url, ua, payload, nil)
+			_, err := SendHTTPRequest(context.Background(), m.httpClientRegVal, http.MethodPost, url, ua, payload, nil)
 			relayRespCh <- err
 			if err != nil {
 				log.WithError(err).Warn("error calling registerValidator on relay")
@@ -302,7 +313,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			url := relay.GetURI(path)
 			log := log.WithField("url", url)
 			responsePayload := new(types.GetHeaderResponse)
-			code, err := SendHTTPRequest(context.Background(), m.httpClient, http.MethodGet, url, ua, nil, responsePayload)
+			code, err := SendHTTPRequest(context.Background(), m.httpClientGetHeader, http.MethodGet, url, ua, nil, responsePayload)
 			if err != nil {
 				log.WithError(err).Warn("error making request to relay")
 				return
@@ -453,7 +464,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 			log.Debug("calling getPayload")
 
 			responsePayload := new(types.GetPayloadResponse)
-			_, err := SendHTTPRequest(requestCtx, m.httpClient, http.MethodPost, url, ua, payload, responsePayload)
+			_, err := SendHTTPRequest(requestCtx, m.httpClientGetPayload, http.MethodPost, url, ua, payload, responsePayload)
 
 			if err != nil {
 				log.WithError(err).Error("error making request to relay")
@@ -511,7 +522,7 @@ func (m *BoostService) CheckRelays() bool {
 		m.log.WithField("relay", relay.String()).Info("Checking relay")
 
 		url := relay.GetURI(pathStatus)
-		_, err := SendHTTPRequest(context.Background(), m.httpClient, http.MethodGet, url, "", nil, nil)
+		_, err := SendHTTPRequest(context.Background(), m.httpClientGetHeader, http.MethodGet, url, "", nil, nil)
 		if err != nil {
 			m.log.WithError(err).WithField("relay", relay.String()).Error("relay check failed")
 			return false

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -36,12 +36,14 @@ func newTestBackend(t *testing.T, numRelays int, relayTimeout time.Duration) *te
 	}
 
 	opts := BoostServiceOpts{
-		Log:                   testLog,
-		ListenAddr:            "localhost:12345",
-		Relays:                relayEntries,
-		GenesisForkVersionHex: "0x00000000",
-		RelayRequestTimeout:   relayTimeout,
-		RelayCheck:            true,
+		Log:                      testLog,
+		ListenAddr:               "localhost:12345",
+		Relays:                   relayEntries,
+		GenesisForkVersionHex:    "0x00000000",
+		RelayCheck:               true,
+		RequestTimeoutGetHeader:  relayTimeout,
+		RequestTimeoutGetPayload: relayTimeout,
+		RequestTimeoutRegVal:     relayTimeout,
 	}
 	service, err := NewBoostService(opts)
 	require.NoError(t, err)
@@ -70,7 +72,7 @@ func (be *testBackend) request(t *testing.T, method string, path string, payload
 
 func TestNewBoostServiceErrors(t *testing.T) {
 	t.Run("errors when no relays", func(t *testing.T) {
-		_, err := NewBoostService(BoostServiceOpts{testLog, ":123", []RelayEntry{}, "0x00000000", time.Second, true})
+		_, err := NewBoostService(BoostServiceOpts{testLog, ":123", []RelayEntry{}, "0x00000000", true, time.Second, time.Second, time.Second})
 		require.Error(t, err)
 	})
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -113,3 +113,7 @@ type bidRespKey struct {
 	slot      uint64
 	blockHash string
 }
+
+func httpClientDisallowRedirects(req *http.Request, via []*http.Request) error {
+	return http.ErrUseLastResponse
+}


### PR DESCRIPTION
## 📝 Summary

Defines individual relay request timeouts:

```
defaultTimeoutMsGetHeader         = getEnvInt("RELAY_TIMEOUT_MS_GETHEADER", 950)   // timeout for getHeader requests
defaultTimeoutMsGetPayload        = getEnvInt("RELAY_TIMEOUT_MS_GETPAYLOAD", 4000) // timeout for getPayload requests
defaultTimeoutMsRegisterValidator = getEnvInt("RELAY_TIMEOUT_MS_REGVAL", 3000)     // timeout for registerValidator requests
```

Closes https://github.com/flashbots/mev-boost/issues/287 
Closes https://github.com/flashbots/mev-boost/issues/181

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
