### PR TITLE
WIP: (Feedback wanted) Log relay and value of received bids

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -408,6 +408,9 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			// Compare the bid with already known top bid (if any)
 			if result.response.Data != nil {
 				valueDiff := responsePayload.Data.Message.Value.Cmp(&result.response.Data.Message.Value)
+
+				log.Infof("Relay %s offered bid with value %s", relay.String(), responsePayload.Data.Message.Value.String())
+
 				if valueDiff == -1 { // current bid is less profitable than already known one
 					return
 				} else if valueDiff == 0 { // current bid is equally profitable as already known one. Use hash as tiebreaker

--- a/server/service.go
+++ b/server/service.go
@@ -421,7 +421,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 
 			// Use this relay's response as mev-boost response because it's most profitable
-			log.Debug("selecting bid")
+			log.Debug("new best bid")
 			result.response = *responsePayload
 			result.blockHash = blockHash
 			result.t = time.Now()

--- a/server/service.go
+++ b/server/service.go
@@ -395,6 +395,8 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 				return
 			}
 
+			log.Debug("bid received")
+
 			mu.Lock()
 			defer mu.Unlock()
 
@@ -408,9 +410,6 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			// Compare the bid with already known top bid (if any)
 			if result.response.Data != nil {
 				valueDiff := responsePayload.Data.Message.Value.Cmp(&result.response.Data.Message.Value)
-
-				log.Infof("Relay %s offered bid with value %s", relay.String(), responsePayload.Data.Message.Value.String())
-
 				if valueDiff == -1 { // current bid is less profitable than already known one
 					return
 				} else if valueDiff == 0 { // current bid is equally profitable as already known one. Use hash as tiebreaker
@@ -422,7 +421,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 
 			// Use this relay's response as mev-boost response because it's most profitable
-			log.Debug("received a good bid")
+			log.Debug("selecting bid")
 			result.response = *responsePayload
 			result.blockHash = blockHash
 			result.t = time.Now()


### PR DESCRIPTION
## 📝 Summary

Just a quick logging of bid value. This way people can check that, when the have proposed a blinded block, the value they got out of it matches the value communicated by the relay. We're already logging information about the bid being e.g. zero (with a warning), or that we received a valid new bid (with a debug message), so it makes sense to include logging on the actual bid as well. 

#294 is probably a more "complete" solution (with timings and everything), but this was such a simple one-liner that I couldn't resist.

## TODO:
- [x] Determine log level (info, or debug?)
- [ ] Elaborate the _why_ in commit message 

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
"