### PR TITLE
Add linter action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Linting
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+          id: go
+
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49
+          args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+run:
+  timeout: 10m
+  go: 1.18
+
+linters:
+  disable-all: true
+  enable:
+    # Enabled by default
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+
+output:
+  print-issued-lines: true
+  sort-results: true


### PR DESCRIPTION
## 📝 Summary

Add Action to run linters

## ⛱ Motivation and Context

Solves https://github.com/flashbots/mev-boost/issues/304

Added the basic linters that are run by default with `golangci-lint`

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
