### PR TITLE
reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION
 ARG CGO_CFLAGS
 WORKDIR /build
 ADD . /build/
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" -v -o mev-boost .
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" -v -o mev-boost .
 
 FROM alpine
 RUN apk add --no-cache libstdc++ libc6-compat

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,15 @@ v:
 
 .PHONY: build
 build:
-	go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o mev-boost .
+	go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
 
 .PHONY: build-portable
 build-portable:
-	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o mev-boost .
+	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
 
 .PHONY: build-testcli
 build-testcli:
-	go build -ldflags "-X 'github.com/flashbots/mev-boost/config.Version=${VERSION}' -X 'github.com/flashbots/mev-boost/config.BuildTime=$(shell date)'" -v -o test-cli ./cmd/test-cli
+	go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o test-cli ./cmd/test-cli
 
 .PHONY: test
 test:

--- a/config/vars.go
+++ b/config/vars.go
@@ -8,9 +8,6 @@ import (
 var (
 	// Version is the version of the software, set at build time
 	Version = "v1.1.1-dev"
-
-	// BuildTime is the output of `date` at build time. Eg. "Sat Jul 16 13:18:55 CEST 2022"
-	BuildTime string
 )
 
 // Other settings


### PR DESCRIPTION
## 📝 Summary

Enable reproducible builds

```
$ make && sha256sum mev-boost
go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=v1.1.0-4-g9ecbd1f'" -v -o mev-boost .
# github.com/flashbots/mev-boost
ld: warning: could not create compact unwind for _blst_sha256_block_data_order: does not use RBP or RSP based frame
f5859587a788050d265c54f2cdbec1daee2a6bc4c963a8438931db23de84ba21  mev-boost

$ make && sha256sum mev-boost
go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=v1.1.0-4-g9ecbd1f'" -v -o mev-boost .
# github.com/flashbots/mev-boost
ld: warning: could not create compact unwind for _blst_sha256_block_data_order: does not use RBP or RSP based frame
f5859587a788050d265c54f2cdbec1daee2a6bc4c963a8438931db23de84ba21  mev-boost

$ make && sha256sum mev-boost
go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=v1.1.0-4-g9ecbd1f'" -v -o mev-boost .
# github.com/flashbots/mev-boost
ld: warning: could not create compact unwind for _blst_sha256_block_data_order: does not use RBP or RSP based frame
f5859587a788050d265c54f2cdbec1daee2a6bc4c963a8438931db23de84ba21  mev-boost
```

## 📚 References

* https://reproducible-builds.org/
* https://pkg.go.dev/cmd/link
* https://stackoverflow.com/a/63831759
* https://groups.google.com/g/Golang-nuts/c/6K5Ca3GZF5k

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
