### PR TITLE
-relay-check on startup: only error if relays have errors (don't fail)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -135,8 +135,8 @@ func Main() {
 		log.WithError(err).Fatal("failed creating the server")
 	}
 
-	if *relayCheck && !server.CheckRelays() {
-		log.Fatal("no relay available")
+	if *relayCheck && server.CheckRelays() == 0 {
+		log.Error("no relay passed the health-check!")
 	}
 
 	log.Println("listening on", *listenAddr)

--- a/server/service.go
+++ b/server/service.go
@@ -541,7 +541,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 }
 
 // CheckRelays sends a request to each one of the relays previously registered to get their status
-func (m *BoostService) CheckRelays() bool {
+func (m *BoostService) CheckRelays() (numHealthyRelays int) {
 	for _, relay := range m.relays {
 		m.log.WithField("relay", relay.String()).Info("Checking relay")
 
@@ -549,9 +549,10 @@ func (m *BoostService) CheckRelays() bool {
 		_, err := SendHTTPRequest(context.Background(), m.httpClientGetHeader, http.MethodGet, url, "", nil, nil)
 		if err != nil {
 			m.log.WithError(err).WithField("relay", relay.String()).Error("relay check failed")
-			return false
+		} else {
+			numHealthyRelays++
 		}
 	}
 
-	return true
+	return numHealthyRelays
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -502,16 +502,16 @@ func TestGetPayload(t *testing.T) {
 func TestCheckRelays(t *testing.T) {
 	t.Run("At least one relay is okay", func(t *testing.T) {
 		backend := newTestBackend(t, 3, time.Second)
-		status := backend.boost.CheckRelays()
-		require.Equal(t, true, status)
+		numHealthyRelays := backend.boost.CheckRelays()
+		require.Equal(t, 3, numHealthyRelays)
 	})
 
 	t.Run("Every relays are down", func(t *testing.T) {
 		backend := newTestBackend(t, 1, time.Second)
 		backend.relays[0].Server.Close()
 
-		status := backend.boost.CheckRelays()
-		require.Equal(t, false, status)
+		numHealthyRelays := backend.boost.CheckRelays()
+		require.Equal(t, 0, numHealthyRelays)
 	})
 
 	t.Run("Should not follow redirects", func(t *testing.T) {
@@ -524,8 +524,8 @@ func TestCheckRelays(t *testing.T) {
 		url, err := url.ParseRequestURI(backend.relays[0].Server.URL)
 		require.NoError(t, err)
 		backend.boost.relays[0].URL = url
-		status := backend.boost.CheckRelays()
-		require.Equal(t, false, status)
+		numHealthyRelays := backend.boost.CheckRelays()
+		require.Equal(t, 0, numHealthyRelays)
 	})
 }
 


### PR DESCRIPTION
## 📝 Summary

Changed the behavior of `-relay-check` to only print errors instead of failing at startup. 

Closes https://github.com/flashbots/mev-boost/issues/312

## ⛱ Motivation and Context

Previously, mev-boost failed on startup if any single relay is not passing the healthcheck, when `-relay-check` is provided.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
