### PR TITLE
getpayload: log request body on error

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -427,15 +429,24 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 
 	log.Debug("getPayload")
 
+	// Read the body first, so we can log it later on error
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		log.WithError(err).Error("could not read body of request from the beacon node")
+		m.respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Decode the body now
 	payload := new(types.SignedBlindedBeaconBlock)
-	if err := DecodeJSON(req.Body, &payload); err != nil {
-		log.WithError(err).Error("could not decode request payload from the beacon-node (signed blinded beacon block)")
+	if err := DecodeJSON(bytes.NewReader(body), payload); err != nil {
+		log.WithError(err).WithField("body", string(body)).Error("could not decode request payload from the beacon-node (signed blinded beacon block)")
 		m.respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	if payload.Message == nil || payload.Message.Body == nil || payload.Message.Body.ExecutionPayloadHeader == nil {
-		log.Error("missing parts of the request payload from the beacon-node")
+		log.WithField("body", string(body)).Error("missing parts of the request payload from the beacon-node")
 		m.respondError(w, http.StatusBadRequest, "missing parts of the payload")
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

log request body on getPayload decoding error. This would simplify debugging.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
