### PR TITLE
Print relays/monitors on individual lines

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -59,7 +59,7 @@ var (
 	useCustomGenesisForkVersion  = flag.String("genesis-fork-version", defaultGenesisForkVersion, "use a custom genesis fork version")
 )
 
-var log = logrus.WithField("module", "cli")
+var log = logrus.NewEntry(logrus.New())
 
 // Main starts the mev-boost cli
 func Main() {
@@ -119,11 +119,17 @@ func Main() {
 		flag.Usage()
 		log.Fatal("no relays specified")
 	}
-	log.WithField("relays", server.RelayEntriesToStrings(relays)).Infof("using %d relays", len(relays))
+	log.Infof("using %d relays", len(relays))
+	for index, relay := range relays {
+		log.Infof("relay #%d: %s", index+1, relay.String())
+	}
 
 	relayMonitors := parseRelayMonitorURLs(*relayMonitorURLs)
 	if len(relayMonitors) > 0 {
-		log.WithField("relay-monitors", relayMonitors).Infof("using %d relay monitors", len(relayMonitors))
+		log.Infof("using %d relay monitors", len(relayMonitors))
+		for index, relayMonitor := range relayMonitors {
+			log.Infof("relay-monitor #%d: %s", index+1, relayMonitor.String())
+		}
 	}
 
 	opts := server.BoostServiceOpts{


### PR DESCRIPTION
## 📝 Summary

* Instead of logging the relays/monitors as a slice, print each one on an individual line.
* Also, remove the `module=cli` field. Personally I don't find it that useful.

From this:

<img width="1331" alt="Screen Shot 2022-09-23 at 10 44 14 AM" src="https://user-images.githubusercontent.com/95511699/192001719-3cb172ff-9023-49d2-a214-99de12581a1f.png">

To this:

<img width="1314" alt="Screen Shot 2022-09-23 at 10 43 17 AM" src="https://user-images.githubusercontent.com/95511699/192001742-9baabcca-feee-4959-b10a-f663711565cb.png">

## ⛱ Motivation and Context

This has been kind of bothering me for a while. With lots of relays, it could be really hard to read.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
