### PR TITLE
Remove unnecessary log.WithField calls

### DIFF
--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/flashbots/mev-boost/server"
 )
 
-var log = logrus.WithField("service", "cmd/test-cli")
+var log = logrus.NewEntry(logrus.New())
 
 func doGenerateValidator(filePath string, gasLimit uint64, feeRecipient string) {
 	v := newRandomValidator(gasLimit, feeRecipient)

--- a/server/mock_types.go
+++ b/server/mock_types.go
@@ -7,7 +7,7 @@ import (
 )
 
 // testLog is used to log information in the test methods
-var testLog = logrus.WithField("testing", true)
+var testLog = logrus.NewEntry(logrus.New())
 
 // _HexToBytes converts a hexadecimal string to a byte array
 func _HexToBytes(hex string) []byte {

--- a/server/service.go
+++ b/server/service.go
@@ -86,7 +86,7 @@ func NewBoostService(opts BoostServiceOpts) (*BoostService, error) {
 		listenAddr:    opts.ListenAddr,
 		relays:        opts.Relays,
 		relayMonitors: opts.RelayMonitors,
-		log:           opts.Log.WithField("module", "service"),
+		log:           opts.Log,
 		relayCheck:    opts.RelayCheck,
 		bids:          make(map[bidRespKey]bidResp),
 


### PR DESCRIPTION
## 📝 Summary

* Removes `WithField` calls with hardcoded values that aren't really that useful.

## ⛱ Motivation and Context

* https://github.com/flashbots/mev-boost/pull/349#issuecomment-1256434855
* I don't think these provide that much value.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
