### PR TITLE
add a -log-service cli flag

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -40,6 +40,7 @@ var (
 	logJSON      = flag.Bool("json", defaultLogJSON, "log in JSON format instead of text")
 	logLevel     = flag.String("loglevel", defaultLogLevel, "minimum loglevel: trace, debug, info, warn/warning, error, fatal, panic")
 	logDebug     = flag.Bool("debug", false, "shorthand for '-loglevel debug'")
+	logService   = flag.String("log-service", "", "add a 'service=...' tag to all log messages")
 
 	listenAddr       = flag.String("addr", defaultListenAddr, "listen-address for mev-boost server")
 	relayURLs        = flag.String("relays", "", "relay urls - single entry or comma-separated list (scheme://pubkey@host)")
@@ -89,6 +90,9 @@ func Main() {
 			log.Fatalf("invalid loglevel: %s", *logLevel)
 		}
 		logrus.SetLevel(lvl)
+	}
+	if *logService != "" {
+		log = log.WithField("service", *logService)
 	}
 
 	log.Infof("mev-boost %s", config.Version)


### PR DESCRIPTION
## 📝 Summary

For production logs it's sometimes useful to add a dedicated `service` tag to distinguish services by their logs only. This PR adds a `-log-service` flag, which when given adds a `service=...` tag to each and ever log message.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
