### PR TITLE
getPayload: log info only if request was cancelled because another relay delivered the payload already

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -489,7 +489,11 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 			responsePayload := new(types.GetPayloadResponse)
 			_, err := SendHTTPRequest(requestCtx, m.httpClientGetPayload, http.MethodPost, url, ua, payload, responsePayload)
 			if err != nil {
-				log.WithError(err).Error("error making request to relay")
+				if errors.Is(requestCtx.Err(), context.Canceled) {
+					log.Info("request was cancelled") // this is expected, if payload has already been received by another relay
+				} else {
+					log.WithError(err).Error("error making request to relay")
+				}
 				return
 			}
 


### PR DESCRIPTION
## 📝 Summary

* If two relays delivered the same bid, mev-boost would ask the payload from both relays. 
* As soon as one relay delivers the payload, the request to the other relay is cancelled.
* This change will only log the information that the request was cancelled instead of logging an error

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
