### PR TITLE
collapsible markup bug - Systemd configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ docker run flashbots/mev-boost -help
 
 You can run MEV-Boost with a systemd config like this:
 
-<details>
-    <summary>`/etc/systemd/system/mev-boost.service`</summary>
+`/etc/systemd/system/mev-boost.service`
 ```ini
 [Unit]
 Description=mev-boost
@@ -168,7 +167,6 @@ ExecStart=/home/mev-boost/bin/mev-boost \
 [Install]
 WantedBy=multi-user.target
 ```
-</details>
 
 ## Troubleshooting
 


### PR DESCRIPTION
The ## Systemd configuration <details> tag is not closing properly. Rest of the content is nested under the dropdown. Suggest removing it or fixing the collapsible tagging.

## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
