### PR TITLE
Fix systemd configuration section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ docker run flashbots/mev-boost -help
 You can run MEV-Boost with a systemd config like this:
 
 <details>
-    <summary>`/etc/systemd/system/mev-boost.service`</summary>
+<summary><code>/etc/systemd/system/mev-boost.service</code></summary>
+
 ```ini
 [Unit]
 Description=mev-boost


### PR DESCRIPTION
## 📝 Summary

This section isn't showing up correctly and is preventing the end of the readme from loading:

<img width="924" alt="image" src="https://user-images.githubusercontent.com/95511699/192407145-52ad8aa6-d7a3-4a3e-9c66-a2dcc8e498e3.png">

* Add a space between `<summary>` and code block.
* Use the `<code>` tag instead of backticks because those don't work in HTML tags.

## ⛱ Motivation and Context

Need to fix this so the whole readme is visible.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
