### PR TITLE
log version always, fix loglevel config

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -72,6 +72,10 @@ func Main() {
 		return
 	}
 
+	// Add version to logs
+	log = log.WithField("version", config.Version)
+
+	// Set log format (json or text)
 	if *logJSON {
 		log.Logger.SetFormatter(&logrus.JSONFormatter{})
 	} else {
@@ -80,6 +84,7 @@ func Main() {
 		})
 	}
 
+	// Set loglevel
 	if *logDebug {
 		*logLevel = "debug"
 	}
@@ -89,8 +94,10 @@ func Main() {
 			flag.Usage()
 			log.Fatalf("invalid loglevel: %s", *logLevel)
 		}
-		logrus.SetLevel(lvl)
+		log.Logger.SetLevel(lvl)
 	}
+
+	// Add the service tag to logs, if configured
 	if *logService != "" {
 		log = log.WithField("service", *logService)
 	}

--- a/server/service.go
+++ b/server/service.go
@@ -268,7 +268,6 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		"slot":       slot,
 		"parentHash": parentHashHex,
 		"pubkey":     pubkey,
-		"version":    config.Version,
 	})
 	log.Debug("getHeader")
 
@@ -418,11 +417,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 }
 
 func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request) {
-	log := m.log.WithFields(logrus.Fields{
-		"method":  "getPayload",
-		"version": config.Version,
-	})
-
+	log := m.log.WithField("method", "getPayload")
 	log.Debug("getPayload")
 
 	// Read the body first, so we can log it later on error


### PR DESCRIPTION
## 📝 Summary

* always log the mev-boost version (simplifies debugging)
* fix custom loglevel (bug introduced in a previous commit, but was not released
* opt-out flag: `-log-no-version` / env var `DISABLE_LOG_VERSION`

```
INFO[2022-09-29T21:42:42+02:00] starting mev-boost                            version=v1.3.3-dev
DEBU[2022-09-29T21:42:42+02:00] debug logging enabled                         version=v1.3.3-dev
INFO[2022-09-29T21:42:42+02:00] using genesis fork version: 0x00000000        version=v1.3.3-dev
INFO[2022-09-29T21:42:42+02:00] using 6 relays                                version=v1.3.3-dev
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
