### PR TITLE
accept gzip encoding

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -26,11 +26,15 @@ var (
 	defaultListenAddr         = getEnv("BOOST_LISTEN_ADDR", "localhost:18550")
 	defaultRelayCheck         = os.Getenv("RELAY_STARTUP_CHECK") != ""
 	defaultGenesisForkVersion = getEnv("GENESIS_FORK_VERSION", "")
+	defaultDisableLogVersion  = os.Getenv("DISABLE_LOG_VERSION") == "1" // disables adding the version to every log entry
 
 	// mev-boost relay request timeouts (see also https://github.com/flashbots/mev-boost/issues/287)
 	defaultTimeoutMsGetHeader         = getEnvInt("RELAY_TIMEOUT_MS_GETHEADER", 950)   // timeout for getHeader requests
 	defaultTimeoutMsGetPayload        = getEnvInt("RELAY_TIMEOUT_MS_GETPAYLOAD", 4000) // timeout for getPayload requests
 	defaultTimeoutMsRegisterValidator = getEnvInt("RELAY_TIMEOUT_MS_REGVAL", 3000)     // timeout for registerValidator requests
+
+	relays        relayList
+	relayMonitors relayMonitorList
 
 	// cli flags
 	printVersion = flag.Bool("version", false, "only print version")
@@ -38,9 +42,7 @@ var (
 	logLevel     = flag.String("loglevel", defaultLogLevel, "minimum loglevel: trace, debug, info, warn/warning, error, fatal, panic")
 	logDebug     = flag.Bool("debug", false, "shorthand for '-loglevel debug'")
 	logService   = flag.String("log-service", "", "add a 'service=...' tag to all log messages")
-
-	relays        relayList
-	relayMonitors relayMonitorList
+	logNoVersion = flag.Bool("log-no-version", defaultDisableLogVersion, "disables adding the version to every log entry")
 
 	listenAddr       = flag.String("addr", defaultListenAddr, "listen-address for mev-boost server")
 	relayURLs        = flag.String("relays", "", "relay urls - single entry or comma-separated list (scheme://pubkey@host)")
@@ -72,6 +74,7 @@ func Main() {
 		return
 	}
 
+	// Set log format (json or text)
 	if *logJSON {
 		log.Logger.SetFormatter(&logrus.JSONFormatter{})
 	} else {
@@ -80,6 +83,7 @@ func Main() {
 		})
 	}
 
+	// Set loglevel
 	if *logDebug {
 		*logLevel = "debug"
 	}
@@ -89,13 +93,22 @@ func Main() {
 			flag.Usage()
 			log.Fatalf("invalid loglevel: %s", *logLevel)
 		}
-		logrus.SetLevel(lvl)
+		log.Logger.SetLevel(lvl)
 	}
+
+	// Add the service tag to logs, if configured
 	if *logService != "" {
 		log = log.WithField("service", *logService)
 	}
 
-	log.Infof("mev-boost %s", config.Version)
+	// Add version to logs and say hello
+	addVersionToLogs := !*logNoVersion
+	if addVersionToLogs {
+		log = log.WithField("version", config.Version)
+		log.Infof("starting mev-boost")
+	} else {
+		log.Infof("starting mev-boost %s", config.Version)
+	}
 	log.Debug("debug logging enabled")
 
 	genesisForkVersionHex := ""

--- a/server/service.go
+++ b/server/service.go
@@ -268,7 +268,6 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		"slot":       slot,
 		"parentHash": parentHashHex,
 		"pubkey":     pubkey,
-		"version":    config.Version,
 	})
 	log.Debug("getHeader")
 
@@ -418,11 +417,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 }
 
 func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request) {
-	log := m.log.WithFields(logrus.Fields{
-		"method":  "getPayload",
-		"version": config.Version,
-	})
-
+	log := m.log.WithField("method", "getPayload")
 	log.Debug("getPayload")
 
 	// Read the body first, so we can log it later on error

--- a/server/utils.go
+++ b/server/utils.go
@@ -39,7 +39,7 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 
 		// Set headers
 		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("accept-encoding", "gzip, deflate")
+		req.Header.Add("Accept-Encoding", "gzip")
 	}
 	if err != nil {
 		return 0, fmt.Errorf("could not prepare request: %w", err)

--- a/server/utils.go
+++ b/server/utils.go
@@ -37,8 +37,9 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 		}
 		req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payloadBytes))
 
-		// Set content-type
+		// Set headers
 		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("accept-encoding", "gzip, deflate")
 	}
 	if err != nil {
 		return 0, fmt.Errorf("could not prepare request: %w", err)


### PR DESCRIPTION
## 📝 Summary

From a discussion with @zeroecco on how to lower bandwidth on the blocknative relay we came to the idea that we could utilize well known compression like gzip, but only if requests coming from mev-boost specified that.

Minimum transmittable unit is 1500 Bytes total w/ 1250 Bytes realistically usable and a block is around ~12KB, gzip will compress ~60% to ~6Kb which would be a packet reduction from 10 to 5 for the total packet train. This also reduces time to last packet and bandwidth, which could be 1 - 5ms based on response time at this size.

If a system doesn't have this enabled the content-encoding will simply be ignored.
On top of that, this improvement will really only be visible for GetPayload response.


To benefit from this in your relay or other components make sure you configure your reverse proxy [HA Proxy, NGINX, etc] to support gzip!


## ⛱ Motivation and Context

I want to go fast

## 📚 References

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding

https://www.rfc-editor.org/rfc/rfc2616#section-3.5

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
