### PR TITLE
getHeader: print bid value in eth instead of wei

### DIFF
--- a/cli/types.go
+++ b/cli/types.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
-	"github.com/flashbots/mev-boost/server"
-	"strings"
-	"net/url"
 	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/flashbots/mev-boost/server"
 )
 
 var errDuplicateEntry = errors.New("duplicate entry")

--- a/server/service.go
+++ b/server/service.go
@@ -318,11 +318,12 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 
 			blockHash := responsePayload.Data.Message.Header.BlockHash.String()
+			valueEth := weiBigIntToEthBigFloat(responsePayload.Data.Message.Value.BigInt())
 			log = log.WithFields(logrus.Fields{
 				"blockNumber": responsePayload.Data.Message.Header.BlockNumber,
 				"blockHash":   blockHash,
 				"txRoot":      responsePayload.Data.Message.Header.TransactionsRoot.String(),
-				"value":       responsePayload.Data.Message.Value.String(),
+				"value":       valueEth.Text('f', 18),
 			})
 
 			if relay.PublicKey != responsePayload.Data.Message.Pubkey {
@@ -397,12 +398,13 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Log result
+	valueEth := weiBigIntToEthBigFloat(result.response.Data.Message.Value.BigInt())
 	result.relays = relays[BlockHashHex(result.blockHash)]
 	log.WithFields(logrus.Fields{
 		"blockHash":   result.blockHash,
 		"blockNumber": result.response.Data.Message.Header.BlockNumber,
 		"txRoot":      result.response.Data.Message.Header.TransactionsRoot.String(),
-		"value":       result.response.Data.Message.Value.String(),
+		"value":       valueEth.Text('f', 18),
 		"relays":      strings.Join(RelayEntriesToStrings(result.relays), ", "),
 	}).Info("best bid")
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
@@ -128,4 +129,12 @@ type bidRespKey struct {
 
 func httpClientDisallowRedirects(req *http.Request, via []*http.Request) error {
 	return http.ErrUseLastResponse
+}
+
+func weiBigIntToEthBigFloat(wei *big.Int) (ethValue *big.Float) {
+	// wei / 10^18
+	fbalance := new(big.Float)
+	fbalance.SetString(wei.String())
+	ethValue = new(big.Float).Quo(fbalance, big.NewFloat(1e18))
+	return
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -59,4 +60,16 @@ func TestSendHTTPRequestUserAgent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, code)
 	<-done
+}
+
+func TestWeiBigIntToEthBigFloat(t *testing.T) {
+	// test with valid input
+	i := big.NewInt(1)
+	f := weiBigIntToEthBigFloat(i)
+	require.Equal(t, "0.000000000000000001", f.Text('f', 18))
+
+	// test with nil, which results on invalid big.Int input
+	f = weiBigIntToEthBigFloat(nil)
+	require.Equal(t, "0.000000000000000000", f.Text('f', 18))
+
 }


### PR DESCRIPTION
## 📝 Summary

Request for discussion

This PR prints the getHeader bid values in ETH instead of wei (which is a popular community request)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
