### PR TITLE
Enable more golangci checks & remove revive

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,6 @@ jobs:
           git diff-index HEAD
           git diff-index --quiet HEAD
 
-      - name: Install revive linter
-        run: go install github.com/mgechev/revive@v1.1.3
-
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@v0.3.1
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,59 @@
-run:
-  timeout: 10m
-  go: 1.18
-
 linters:
-  disable-all: true
-  enable:
-    # Enabled by default
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
+  enable-all: true
+  disable:
+    - exhaustruct
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocritic
+    - godot
+    - godox
+    - gomnd
+    - lll
+    - nlreturn
+    - nonamedreturns
+    - nosnakecase
+    - paralleltest
+    - testpackage
+    - varnamelen
+    - wrapcheck
+    - wsl
+
+    #
+    # Maybe fix later:
+    #
+    - cyclop
+    - gocognit
+    - goconst
+    - gosec
+    - ireturn
+    - noctx
+    - tagliatelle
+
+    #
+    # Disabled because of generics:
+    #
+    - contextcheck
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - wastedassign
+
+    #
+    # Disabled because deprecated:
+    #
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - scopelint
+    - varcheck
+
+linters-settings:
+  gofumpt:
+    extra-rules: true
 
 output:
   print-issued-lines: true

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ test-race:
 
 .PHONY: lint
 lint:
+	gofmt -d -s .
 	gofumpt -d -extra .
-	revive -set_exit_status ./...
 	go vet ./...
 	staticcheck ./...
-	golangci-lint run --config=.golangci.yml
+	golangci-lint run
 
 .PHONY: test-coverage
 test-coverage:

--- a/cli/main.go
+++ b/cli/main.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -69,11 +68,6 @@ func Main() {
 	flag.Parse()
 	logrus.SetOutput(os.Stdout)
 
-	if *printVersion {
-		fmt.Printf("mev-boost %s\n", config.Version)
-		return
-	}
-
 	// Set log format (json or text)
 	if *logJSON {
 		log.Logger.SetFormatter(&logrus.JSONFormatter{})
@@ -81,6 +75,11 @@ func Main() {
 		log.Logger.SetFormatter(&logrus.TextFormatter{
 			FullTimestamp: true,
 		})
+	}
+
+	if *printVersion {
+		log.Infof("mev-boost %s\n", config.Version)
+		return
 	}
 
 	// Set loglevel

--- a/cli/types.go
+++ b/cli/types.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
-	"github.com/flashbots/mev-boost/server"
-	"strings"
-	"net/url"
 	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/flashbots/mev-boost/server"
 )
 
 var errDuplicateEntry = errors.New("duplicate entry")
@@ -39,7 +40,7 @@ func (r *relayList) Set(value string) error {
 type relayMonitorList []*url.URL
 
 func (rm *relayMonitorList) String() string {
-	relayMonitors := make([]string, len(*rm))
+	relayMonitors := []string{}
 	for _, relayMonitor := range *rm {
 		relayMonitors = append(relayMonitors, relayMonitor.String())
 	}

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -238,7 +238,7 @@ func main() {
 		}
 		doGetPayload(mustLoadValidator(validatorDataFile), boostEndpoint, createBeacon(isMergemock, beaconEndpoint, engineEndpoint), engineEndpoint, builderSigningDomain, proposerSigningDomain)
 	default:
-		fmt.Println("Expected generate|register|getHeader|getPayload subcommand")
+		log.Info("Expected generate|register|getHeader|getPayload subcommand")
 		os.Exit(1)
 	}
 }

--- a/cmd/test-cli/requests.go
+++ b/cmd/test-cli/requests.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 )
+
+var errRequestResponse = errors.New("request response error")
 
 type jsonrpcMessage struct {
 	Version string          `json:"jsonrpc,omitempty"`
@@ -30,7 +33,7 @@ func sendJSONRequest(endpoint string, payload, dst any) error {
 	body := bytes.NewReader(payloadBytes)
 	fetchLog := log.WithField("endpoint", endpoint).WithField("method", "POST").WithField("payload", string(payloadBytes))
 	fetchLog.Info("sending request")
-	req, err := http.NewRequest("POST", endpoint, body)
+	req, err := http.NewRequest(http.MethodPost, endpoint, body)
 	if err != nil {
 		fetchLog.WithError(err).Error("could not prepare request")
 		return err
@@ -62,7 +65,7 @@ func sendJSONRequest(endpoint string, payload, dst any) error {
 
 	if jsonResp.Error != nil {
 		fetchLog.WithField("code", jsonResp.Error.Code).WithField("err", jsonResp.Error.Message).Error("error response")
-		return errors.New(jsonResp.Error.Message)
+		return fmt.Errorf("%w: %s", errRequestResponse, jsonResp.Error.Message)
 	}
 
 	if dst != nil {

--- a/server/mock_relay.go
+++ b/server/mock_relay.go
@@ -58,6 +58,7 @@ type mockRelay struct {
 // newMockRelay creates a mocked relay which implements the backend.BoostBackend interface
 // A secret key must be provided to sign default and custom response messages
 func newMockRelay(t *testing.T) *mockRelay {
+	t.Helper()
 	relay := &mockRelay{t: t, secretKey: mockRelaySecretKey, publicKey: mockRelayPublicKey, requestCount: make(map[string]int)}
 
 	// Initialize server

--- a/server/mock_relay_test.go
+++ b/server/mock_relay_test.go
@@ -12,7 +12,7 @@ import (
 func Test_mockRelay(t *testing.T) {
 	t.Run("bad payload", func(t *testing.T) {
 		relay := newMockRelay(t)
-		req, err := http.NewRequest("POST", pathRegisterValidator, bytes.NewReader([]byte("123")))
+		req, err := http.NewRequest(http.MethodPost, pathRegisterValidator, bytes.NewReader([]byte("123")))
 		require.NoError(t, err)
 		rr := httptest.NewRecorder()
 		relay.getRouter().ServeHTTP(rr, req)

--- a/server/service.go
+++ b/server/service.go
@@ -23,12 +23,12 @@ import (
 )
 
 var (
+	errNoRelays                  = errors.New("no relays")
 	errInvalidSlot               = errors.New("invalid slot")
 	errInvalidHash               = errors.New("invalid hash")
 	errInvalidPubkey             = errors.New("invalid pubkey")
 	errNoSuccessfulRelayResponse = errors.New("no successful relay response")
-
-	errServerAlreadyRunning = errors.New("server already running")
+	errServerAlreadyRunning      = errors.New("server already running")
 )
 
 var (
@@ -76,7 +76,7 @@ type BoostService struct {
 // NewBoostService created a new BoostService
 func NewBoostService(opts BoostServiceOpts) (*BoostService, error) {
 	if len(opts.Relays) == 0 {
-		return nil, errors.New("no relays")
+		return nil, errNoRelays
 	}
 
 	builderSigningDomain, err := ComputeDomain(types.DomainTypeAppBuilder, opts.GenesisForkVersionHex, types.Root{}.String())
@@ -162,7 +162,7 @@ func (m *BoostService) StartHTTPServer() error {
 	}
 
 	err := m.srv.ListenAndServe()
-	if err == http.ErrServerClosed {
+	if errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}
 	return err

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -25,6 +25,7 @@ type testBackend struct {
 
 // newTestBackend creates a new backend, initializes mock relays, registers them and return the instance
 func newTestBackend(t *testing.T, numRelays int, relayTimeout time.Duration) *testBackend {
+	t.Helper()
 	backend := testBackend{
 		relays: make([]*mockRelay, numRelays),
 	}
@@ -54,6 +55,7 @@ func newTestBackend(t *testing.T, numRelays int, relayTimeout time.Duration) *te
 }
 
 func (be *testBackend) request(t *testing.T, method, path string, payload any) *httptest.ResponseRecorder {
+	t.Helper()
 	var req *http.Request
 	var err error
 
@@ -108,7 +110,7 @@ func TestWebserverRootHandler(t *testing.T) {
 	backend := newTestBackend(t, 1, time.Second)
 
 	// Check root handler
-	req, _ := http.NewRequest("GET", "/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 	backend.boost.getRouter().ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)

--- a/server/utils.go
+++ b/server/utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/flashbots/mev-boost/config"
 )
 
+var (
+	errHTTPErrorResponse  = errors.New("HTTP error response")
+	errInvalidForkVersion = errors.New("invalid fork version")
+)
+
 // UserAgent is a custom string type to avoid confusing url + userAgent parameters in SendHTTPRequest
 type UserAgent string
 
@@ -63,7 +68,7 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 		if err != nil {
 			return resp.StatusCode, fmt.Errorf("could not read error response body for status code %d: %w", resp.StatusCode, err)
 		}
-		return resp.StatusCode, fmt.Errorf("HTTP error response: %d / %s", resp.StatusCode, string(bodyBytes))
+		return resp.StatusCode, fmt.Errorf("%w: %d / %s", errHTTPErrorResponse, resp.StatusCode, string(bodyBytes))
 	}
 
 	if dst != nil {
@@ -85,8 +90,7 @@ func ComputeDomain(domainType types.DomainType, forkVersionHex, genesisValidator
 	genesisValidatorsRoot := types.Root(common.HexToHash(genesisValidatorsRootHex))
 	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
 	if err != nil || len(forkVersionBytes) > 4 {
-		err = errors.New("invalid fork version passed")
-		return domain, err
+		return domain, errInvalidForkVersion
 	}
 	var forkVersion [4]byte
 	copy(forkVersion[:], forkVersionBytes[:4])


### PR DESCRIPTION
## 📝 Summary

* Essentially, copy `.golangci.yml` file from go-boost-utils.
  * By default, everything is enabled. Then we disable checks we don't like.
* Remove revive as it's run by golangci anyway.
* Copy `make lint` rule from go-boost-utils/mev-boost-relay.
  * This calls `gofumpt` with extra checks.
  * And gofmt with simplify.
* Fix findings from a few different linters:
  * Use go1.13 style errors.
  * Replace `fmt.Info` calls with `log.Info` calls.
  * Print version after the `SetFormatter` call.
  * Fix bug in `relayMonitorList.String()` that `makezero` identified.
  * Call `t.Helper()` at the beginning of helper functions.
  * Replace `"POST"` with `http.MethodPost` in `http.NewRequest` calls.

## ⛱ Motivation and Context

Just want to keep things consistent between the three projects.

I may review the disabled checks again later and try to fix some more stuff.

Fixes #306.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
