### PR TITLE
Cleanup deprecated testnets from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ Alternatively, run mev-boost without build step:
 ```bash
 go run . -h
 
-# Run mev-boost pointed at our Kiln builder+relay
-go run . -kiln -relays https://0xb5246e299aeb782fbc7c91b41b3284245b1ed5206134b0028b81dfb974e5900616c67847c2354479934fc4bb75519ee1@builder-relay-kiln.flashbots.net
+# Run mev-boost pointed at our goerli builder+relay
+go run . -goerli -relay-check -relays https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@builder-relay-goerli.flashbots.net
 ```
 
-Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-kiln`/`-ropsten`/`-sepolia`).
+Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-goerli`/`-sepolia`).
 
 If the test or target application crashes with an "illegal instruction" exception, run/rebuild with CGO_CFLAGS environment variable set to `-O -D__BLST_PORTABLE__`. This error also happens if you are on an ARM-based system, including the Apple M1/M2 chip.
 

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -27,8 +27,7 @@ Env & defaults:
 	-vd-file                  VALIDATOR_DATA_FILE     = ./validator_data.json
 	-mev-boost                MEV_BOOST_ENDPOINT      = http://127.0.0.1:18550
 	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
-	                                                    "0x70000069" (kiln)
-	                                                    "0x80000069" (ropsten)
+														"0x00001020" (goerli)
 	                                                    "0x90000069" (sepolia)
 
 	[getHeader]
@@ -39,8 +38,7 @@ Env & defaults:
 	-mm                                                      - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
 
 	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
-	                                                    "0x70000069" (kiln)
-	                                                    "0x80000069" (ropsten)
+														"0x00001020" (goerli)
 	                                                    "0x90000069" (sepolia)
 
 	[getPayload]
@@ -51,18 +49,15 @@ Env & defaults:
 	-mm                                                      - mergemock mode, use mergemock defaults, only call execution and use fake slot in getHeader
 
 	-genesis-validators-root  GENESIS_VALIDATORS_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000" (mainnet) - network genesis validators root
-	                                                    "0x99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad" (kiln)
-	                                                    "0x44f1e56283ca88b35c789f7f449e52339bc1fefe3a45913a43a6d16edcd33cf1" (ropsten)
+														"0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a" (goerli)
 	                                                    "0xd8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078" (sepolia)
 
 	-genesis-fork-version     GENESIS_FORK_VERSION    = "0x00000000" (mainnet) - network fork version
-	                                                    "0x70000069" (kiln)
-	                                                    "0x80000069" (ropsten)
+														"0x00001020" (goerli)
 	                                                    "0x90000069" (sepolia)
 
 	-bellatrix-fork-version   BELLATRIX_FORK_VERSION  = "0x02000000" (mainnet) - network bellatrix fork version
-	                                                    "0x70000071" (kiln)
-	                                                    "0x80000071" (ropsten)
+														"0x02001020" (goerli)
 	                                                    "0x90000071" (sepolia)
 ```
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
