### PR TITLE
readme: clarify that usage is about main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,17 @@ A single MEV-Boost instance can be used by multiple beacon nodes and validators.
 
 Aside from running MEV-Boost on your local network, you must configure:
 * individual **beacon nodes** to connect to MEV-Boost. Beacon Node configuration varies by Consensus client. Guides for each client can be found on the [MEV-boost website](https://boost.flashbots.net/#block-356364ebd7cc424fb524428ed0134b21).
-* individual **validators** to configure a preferred relay selection. Note: validators should take precautions to only connect to trusted relays. Read more about [the role of relays here](https://docs.flashbots.net/flashbots-mev-boost/relays). 
+* individual **validators** to configure a preferred relay selection. Note: validators should take precautions to only connect to trusted relays. Read more about [the role of relays here](https://docs.flashbots.net/flashbots-mev-boost/relays).
 
-Lists of available relays are maintained by 
-* [Ethstaker](https://github.com/remyroy/ethstaker/blob/main/MEV-relay-list.md) 
+Lists of available relays are maintained by
+* [Ethstaker](https://github.com/remyroy/ethstaker/blob/main/MEV-relay-list.md) [[2]](https://ethstaker.cc/mev-relay-list/)
 * [Lido](https://research.lido.fi/t/lido-on-ethereum-call-for-relay-providers/2844)
 
+## Note on usage documentation
+
+The documentation in this README reflects the latest state of the `main` branch, which may have cli flags or functionality not present in the latest release.
+
+Please take a look at the specific release documentation about the available command line flags: https://github.com/flashbots/mev-boost/releases
 
 ## Mainnet
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,4 +84,11 @@ To create a new version (with tag), follow all these steps! They are necessary t
 * Update `Version` in `config/vars.go` to next patch with `dev` suffix (eg. `v2.3.2-dev`), commit to main and push to Github
 * Now push the main and stable branch, as well as the tag to Github: `git push origin main stable --tags`
 
-Now check the Github CI actions for release activity: https://github.com/flashbots/mev-boost/actions - CI builds and pushes the Docker image, and prepares a new draft release in https://github.com/flashbots/mev-boost/releases. Open it, generate the description, review, add signoffs and testing, and publish.
+Now check the Github CI actions for release activity: https://github.com/flashbots/mev-boost/actions
+* CI builds and pushes the Docker image, and prepares a new draft release in https://github.com/flashbots/mev-boost/releases
+* Open it and prepare the release:
+  * generate the description
+  * review
+  * add signoffs and testing
+  * add usage (`mev-boost -help`)
+  * publish


### PR DESCRIPTION
## 📝 Summary

* Make it clear in the README that the usage instructions reflect the `main` branch, not the latest release
* Add generating usage to release instructions

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
