### PR TITLE
Minor release fixes for v1.4.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,11 +27,11 @@ jobs:
         with:
           images: flashbots/mev-boost
           tags: |
-            type=raw,value=latest,enable=${{ !contains(steps.vars.outputs.tag, '-') }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(steps.vars.outputs.tag, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(steps.vars.outputs.tag, '-') }}
+            type=raw,value=latest,enable=${{ !contains(steps.vars.outputs.tag, '-') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,5 +29,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           files: ./coverage.out
-          verbose: true
+          verbose: false
           flags: unittests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,7 +49,10 @@ vim config/vars.go
 git commit -am "v2.3.1-rc1"
 git tag v2.3.1-rc1  # without a tag, building/creating the docker image would include the wrong version number
 
-# create and push the Docker image manually (or push the tag to let CI do that)
+# now push to Github (CI will build the Docker image)
+git push origin v2.3.1-rc1 --tags
+
+# you can also manually create and push the Docker image
 make docker-image-portable
 make docker-push-version
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 	"math/big"
 	"os"
 	"strconv"
@@ -82,7 +83,7 @@ func Main() {
 	}
 
 	if *printVersion {
-		log.Infof("mev-boost %s\n", config.Version)
+		fmt.Printf("mev-boost %s\n", config.Version) //nolint
 		return
 	}
 


### PR DESCRIPTION
## 📝 Summary

* Github CI: on pushing tag with `-` (i.e. `-rc1` suffix), don't override Docker images for major.minor and major builds, but only build tags for sha and specific version
* `mev-boost -version` should print the version without the logging, as is customary
* Updated RELEASE.md
* Less verbose codecov report

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
