### PR TITLE
remove manual gzipping of request, as it's done automatically!

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -45,7 +45,6 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 
 		// Set headers
 		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Accept-Encoding", "gzip")
 	}
 	if err != nil {
 		return 0, fmt.Errorf("could not prepare request: %w", err)

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -61,21 +61,23 @@ func TestSendHTTPRequestUserAgent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, code)
 	<-done
+}
 
+func TestSendHTTPRequestGzip(t *testing.T) {
 	// Test with gzip response
 	var buf bytes.Buffer
 	zw := gzip.NewWriter(&buf)
-	_, err = zw.Write([]byte(`{ "msg": "test-message" }`))
+	_, err := zw.Write([]byte(`{ "msg": "test-message" }`))
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())
 
-	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
 		w.Header().Set("Content-Encoding", "gzip")
 		_, _ = w.Write(buf.Bytes())
 	}))
 	resp := struct{ Msg string }{}
-	code, err = SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, ts.URL, "", nil, &resp)
+	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, ts.URL, "", nil, &resp)
 	ts.Close()
 	require.NoError(t, err)
 	require.Equal(t, 200, code)


### PR DESCRIPTION
## 📝 Summary

Fixes #365 and replaces #382

http.Request automatically adds `Accept-Encoding: gzip` header and transparently decompresses the response. You can see this working in the test in this PR. Also see https://pkg.go.dev/net/http#Response.Uncompressed

But when the header is set manually, then it won't decode the response automatically, which is what we're seeing in #382 

In fact, gzip was already support since the very beginning of mev-boost. :)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
