### PR TITLE
Github CI: portable Docker image suffix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           images: flashbots/mev-boost
           tags: |
             type=sha
-            type=semver,pattern={{version}}-portable
+            type=semver,pattern={{version}},suffix=-portable
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## 📝 Summary

Github CI: proper portable suffix for Docker image

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
