### PR TITLE
Render usage as text instead of bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Run MEV-Boost pointed at a Sepolia relay:
 
 These are the CLI arguments for the main branch. For arguments available in a specific release, check the [release page](https://github.com/flashbots/mev-boost/releases).
 
-```bash
+```
 $ ./mev-boost -help
 Usage of ./mev-boost:
   -addr string


### PR DESCRIPTION
## 📝 Summary

Minor change. In the README, the usage (`mev-boost -help`) should be rendered as text instead of bash.

## ⛱ Motivation and Context

Some of the words (keywords) had syntax highlighting. I found it a bit distracting:

<img width="657" alt="image" src="https://user-images.githubusercontent.com/95511699/198656414-d06f2f3e-f5cc-4db1-8c43-ad69522f43a3.png">

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
