### PR TITLE
Add bug bounty section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See also:
 - [Maintainers](#maintainers)
 - [Contributing](#contributing)
 - [Security](#security)
+  - [Bug Bounty](#bug-bounty)
   - [Audits](#audits)
 - [License](#license)
 
@@ -360,7 +361,18 @@ You are welcome here <3.
 
 # Security
 
-If you find a security vulnerability on this project or any other initiative related to Flashbots, please let us know sending an email to security@flashbots.net.
+If you find a security vulnerability in this project or any other initiative
+related to Flashbots, please let us know sending an email to
+security@flashbots.net. Refer to the [SECURITY file](SECURITY.md) for details.
+
+## Bug Bounty
+
+The bug bounty program will be a shared bounty pool of up to 50k USD
+between `mev-boost`, `mev-boost-relay`.
+
+We would like to welcome node operators, builders, searchers, and other
+participants in the ecosystem to contribute to this bounty pool to help make the
+ecosystem more secure.
 
 ## Audits
 

--- a/README.md
+++ b/README.md
@@ -367,9 +367,7 @@ security@flashbots.net. Refer to the [SECURITY file](SECURITY.md) for details.
 
 ## Bug Bounty
 
-The bug bounty program will be a shared bounty pool of up to $50k USD
-between `mev-boost` and `mev-boost-relay`.
-See [Bug Bounty Program](SECURITY.md#bug-bounty-program) for details.
+We have a bug bounty program! Get up to $25k USD for a critical vulnerability.
 
 We would like to welcome node operators, builders, searchers, and other
 participants in the ecosystem to contribute to this bounty pool to help make the

--- a/README.md
+++ b/README.md
@@ -367,8 +367,9 @@ security@flashbots.net. Refer to the [SECURITY file](SECURITY.md) for details.
 
 ## Bug Bounty
 
-The bug bounty program will be a shared bounty pool of up to 50k USD
-between `mev-boost`, `mev-boost-relay`.
+The bug bounty program will be a shared bounty pool of up to $50k USD
+between `mev-boost` and `mev-boost-relay`.
+See [Bug Bounty Program](SECURITY.md#bug-bounty-program) for details.
 
 We would like to welcome node operators, builders, searchers, and other
 participants in the ecosystem to contribute to this bounty pool to help make the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,3 @@ Please include the steps to reproduce it using as much detail as possible with t
 
 Once we have received your bug report, we will try to reproduce it and provide a more detailed response.
 Once the reported bug has been successfully reproduced, the team will work on a fix.
-
-## Bounty Program
-
-The bug bounty program will be a shared bounty pool of up to 50k USD between `mev-boost`, `mev-boost-relay`.
-
-We would like to welcome node operators, builders, searchers and other participants in the ecosystem to contribute to this bounty pool to help make the ecosystem more secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,49 @@
 # Security Policy
 
-The Flashbots team would appreciate any contributions, responsible disclosures and will make every effort to acknowledge your contributions.
-
-## Scope
-
-Bugs that affect the security of the Ethereum protocol in the `mev-boost` and `mev-boost-relay` repositories are in scope. Bugs in third-party dependencies are not in scope unless they result in a bug in `mev-boost` with demonstrable security impact. 
+The Flashbots team would appreciate any contributions, responsible disclosures
+and will make every effort to acknowledge your contributions.
 
 ## Supported Versions
 
-Please see [Releases](https://github.com/flashbots/mev-boost/releases). Generally it is recommended to use the [latest release](https://github.com/flashbots/mev-boost/releases/latest).
+Please see [Releases](https://github.com/flashbots/mev-boost/releases).
+Generally it is recommended to use
+the [latest release](https://github.com/flashbots/mev-boost/releases/latest).
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please email security@flashbots.net and provide all the necessary details to reproduce it, such as:
+To report a vulnerability, please email security@flashbots.net and provide all
+the necessary details to reproduce it, such as:
 
 - Release version
 - Operating System
 - Consensus / Execution client combination and version
 - Network (Mainnet or other testnet)
 
-Please include the steps to reproduce it using as much detail as possible with the corresponding logs from `mev-boost` and / or logs from the consensus / execution client.
+Please include the steps to reproduce it using as much detail as possible with
+the corresponding logs from `mev-boost` and/or logs from the consensus/execution
+client.
 
-Once we have received your bug report, we will try to reproduce it and provide a more detailed response.
-Once the reported bug has been successfully reproduced, the team will work on a fix.
+Once we have received your bug report, we will try to reproduce it and provide a
+more detailed response. When the reported bug has been successfully reproduced,
+the team will work on a fix.
+
+## Bug Bounty Program
+
+To incentive bug reports, there is a bug bounty program. You can receive a
+bounty (up to $25k USD) depending on the bug's severity. Severity is based on
+impact and likelihood. If a bug is high impact but low likelihood, it will have
+a lower severity than a bug with a high impact and high likelihood.
+
+| Severity |     Maximum | Example                                                                |
+|----------|------------:|------------------------------------------------------------------------|
+| Low      |    $200 USD | A bug that causes mev-boost to skip a bid.                             |
+| Medium   |  $1,000 USD | From a builder message, can cause mev-boost to go offline.             |
+| High     |  $5,000 USD | From a builder message, can cause a connected validator to go offline. |
+| Critical | $25,000 USD | From a builder message, can remotely access arbitrary files on host.   |
+
+### Scope
+
+Bugs that affect the security of the Ethereum protocol in the `mev-boost`
+and `mev-boost-relay` repositories are in scope. Bugs in third-party
+dependencies are not in scope unless they result in a bug in `mev-boost` with
+demonstrable security impact.


### PR DESCRIPTION
## 📝 Summary

During the roundtable at Bogota, someone mentioned that the bug bounty program wasn't on the README when it should have been. This PR moves that section from SECURITY to README. There should be more details about the bug bounty program in that security file though 🔒

Also, I think the details this bug bounty program are pretty vague. What does a "shared pool of $50k" mean exactly? I understand that's the total allocation for the program, but what are the actual expected bounties? If someone finds a critical vulnerability, will they get all of that $50k? A table of maximum bounties would be nice, like:

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/95511699/198668163-2785c0f5-e59f-4c80-bfce-8b5402ead135.png">

## ⛱ Motivation and Context

More exposure for the bug bounty 👍 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
