### PR TITLE
Update broken link `Why run mev-boost?` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flashbots is a research and development organization working on mitigating the n
 
 In the future, [proposer/builder separation](https://ethresear.ch/t/two-slot-proposer-builder-separation/10980) will be enshrined in the Ethereum protocol itself to further harden its trust model.
 
-Read more in [Why run MEV-Boost?](https://writings.flashbots.net/writings/why-run-mevboost/) and in the [Frequently Asked Questions](https://github.com/flashbots/mev-boost/wiki/Frequently-Asked-Questions).
+Read more in [Why run MEV-Boost?](https://writings.flashbots.net/why-run-mevboost/) and in the [Frequently Asked Questions](https://github.com/flashbots/mev-boost/wiki/Frequently-Asked-Questions).
 
 # Installing
 


### PR DESCRIPTION
## 📝 Summary

Non-critical change to update a broken link to a writing article (`Why run mev-boost?`) in the README.

## ⛱ Motivation and Context

Remove the `writings/` path from the URL that returns a 404

```shell
$ curl -s -I https://writings.flashbots.net/writings/why-run-mevboost/ | head -n1
HTTP/2 404

$ curl -s -I https://writings.flashbots.net/why-run-mevboost/ | head -n1
HTTP/2 200
```
---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
