### PR TITLE
json decoding: allow unknown fields (in preparation for Capella and EIP-4844)

### DIFF
--- a/server/mock_relay.go
+++ b/server/mock_relay.go
@@ -139,7 +139,7 @@ func (m *mockRelay) handleRegisterValidator(w http.ResponseWriter, req *http.Req
 	}
 
 	payload := []types.SignedValidatorRegistration{}
-	if err := DecodeJSON(req.Body, &payload); err != nil {
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/server/service.go
+++ b/server/service.go
@@ -242,7 +242,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 	log.Debug("registerValidator")
 
 	payload := []types.SignedValidatorRegistration{}
-	if err := DecodeJSON(req.Body, &payload); err != nil {
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 		m.respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -462,7 +462,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 
 	// Decode the body now
 	payload := new(types.SignedBlindedBeaconBlock)
-	if err := DecodeJSON(bytes.NewReader(body), payload); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(payload); err != nil { // must allow unknown fields to ensure backwards compatibility of future payload changes (i.e. Capella, EIP-4844, etc)
 		log.WithError(err).WithField("body", string(body)).Error("could not decode request payload from the beacon-node (signed blinded beacon block)")
 		m.respondError(w, http.StatusBadRequest, err.Error())
 		return

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,15 @@ import (
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/require"
 )
+
+// _decodeJSON reads JSON from io.Reader and decodes it into a struct
+func _decodeJSON(r io.Reader, dst any) error {
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	return nil
+}
 
 type testBackend struct {
 	boost  *BoostService
@@ -636,7 +646,7 @@ func TestGetPayloadWithTestdata(t *testing.T) {
 			require.NoError(t, err)
 			defer jsonFile.Close()
 			signedBlindedBeaconBlock := new(types.SignedBlindedBeaconBlock)
-			require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBeaconBlock))
+			require.NoError(t, _decodeJSON(jsonFile, &signedBlindedBeaconBlock))
 
 			backend := newTestBackend(t, 1, time.Second)
 			mockResp := types.GetPayloadResponse{
@@ -664,7 +674,7 @@ func TestGetPayloadToOriginRelayOnly(t *testing.T) {
 	require.NoError(t, err)
 	defer jsonFile.Close()
 	signedBlindedBeaconBlock := new(types.SignedBlindedBeaconBlock)
-	require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBeaconBlock))
+	require.NoError(t, _decodeJSON(jsonFile, &signedBlindedBeaconBlock))
 
 	// Create a test backend with 2 relays
 	backend := newTestBackend(t, 2, time.Second)

--- a/server/utils.go
+++ b/server/utils.go
@@ -98,17 +98,6 @@ func ComputeDomain(domainType types.DomainType, forkVersionHex, genesisValidator
 	return types.ComputeDomain(domainType, forkVersion, genesisValidatorsRoot), nil
 }
 
-// DecodeJSON reads JSON from io.Reader and decodes it into a struct
-func DecodeJSON(r io.Reader, dst any) error {
-	decoder := json.NewDecoder(r)
-	decoder.DisallowUnknownFields()
-
-	if err := decoder.Decode(dst); err != nil {
-		return err
-	}
-	return nil
-}
-
 // GetURI returns the full request URI with scheme, host, path and args.
 func GetURI(url *url.URL, path string) string {
 	u2 := *url

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -22,18 +22,6 @@ func TestMakePostRequest(t *testing.T) {
 	require.Equal(t, 0, code)
 }
 
-func TestDecodeJSON(t *testing.T) {
-	// test disallows unknown fields
-	var x struct {
-		A int `json:"a"`
-		B int `json:"b"`
-	}
-	payload := bytes.NewReader([]byte(`{"a":1,"b":2,"c":3}`))
-	err := DecodeJSON(payload, &x)
-	require.Error(t, err)
-	require.Equal(t, "json: unknown field \"c\"", err.Error())
-}
-
 func TestSendHTTPRequestUserAgent(t *testing.T) {
 	done := make(chan bool, 1)
 


### PR DESCRIPTION
## 📝 Summary

This PR allows unknown fields in the JSON request payloads.

* New payload fields will be part of the upcoming Capella and EIP-4844 updates (see also #392)
* These new payload fields would make mev-boost break on the getPayload call unless a new API version is introduced
* Since there's multiple upcoming changes, it seems to be overkill to add a new API version for each update
* The simple solution is to allow unknown fields in the json payload, and have all users upgrade before any payload changes are deployed. This way the can be backwards compatible.
* This limitation was applied only to the registerValidator and getPayload request payload from the beacon-node, where there is not real risk of resource exhaustion (and in case of getPayload the payload was fully read beforehand anyway)

I think this should go into the v1.4.0 release (see #377) in order to strengthen backwards compatibility with future payload additions.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
