### PR TITLE
add mev-boost version as response header to status API call

### DIFF
--- a/config/vars.go
+++ b/config/vars.go
@@ -8,6 +8,9 @@ import (
 var (
 	// Version is the version of the software, set at build time
 	Version = "v1.3.3-dev"
+
+	// ForkVersion is the latest supported fork version at build time
+	ForkVersion = "bellatrix"
 )
 
 // Other settings

--- a/server/service.go
+++ b/server/service.go
@@ -229,6 +229,7 @@ func (m *BoostService) handleRoot(w http.ResponseWriter, req *http.Request) {
 // handleStatus sends calls to the status endpoint of every relay.
 // It returns OK if at least one returned OK, and returns error otherwise.
 func (m *BoostService) handleStatus(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("X-MEVBoost-Version", config.Version)
 	if !m.relayCheck || m.CheckRelays() > 0 {
 		m.respondOK(w, nilResponse)
 	} else {

--- a/server/service.go
+++ b/server/service.go
@@ -230,6 +230,7 @@ func (m *BoostService) handleRoot(w http.ResponseWriter, req *http.Request) {
 // It returns OK if at least one returned OK, and returns error otherwise.
 func (m *BoostService) handleStatus(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("X-MEVBoost-Version", config.Version)
+	w.Header().Set("X-MEVBoost-ForkVersion", config.ForkVersion)
 	if !m.relayCheck || m.CheckRelays() > 0 {
 		m.respondOK(w, nilResponse)
 	} else {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -176,6 +176,7 @@ func TestStatus(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		require.True(t, len(rr.Header().Get("X-MEVBoost-Version")) > 0)
+		require.Equal(t, "bellatrix", rr.Header().Get("X-MEVBoost-ForkVersion"))
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
@@ -188,6 +189,7 @@ func TestStatus(t *testing.T) {
 
 		require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 		require.True(t, len(rr.Header().Get("X-MEVBoost-Version")) > 0)
+		require.Equal(t, "bellatrix", rr.Header().Get("X-MEVBoost-ForkVersion"))
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -175,6 +175,7 @@ func TestStatus(t *testing.T) {
 		rr := backend.request(t, http.MethodGet, path, nil)
 
 		require.Equal(t, http.StatusOK, rr.Code)
+		require.True(t, len(rr.Header().Get("X-MEVBoost-Version")) > 0)
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
@@ -186,6 +187,7 @@ func TestStatus(t *testing.T) {
 		rr := backend.request(t, http.MethodGet, path, nil)
 
 		require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+		require.True(t, len(rr.Header().Get("X-MEVBoost-Version")) > 0)
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
 }


### PR DESCRIPTION
## 📝 Summary

Adds a `X-MEVBoost-Version` header in the status API call response, which allows outside services to detect the mev-boost version.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
