### PR TITLE
Ensure that fork version is 4 bytes

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -90,7 +90,7 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 func ComputeDomain(domainType types.DomainType, forkVersionHex, genesisValidatorsRootHex string) (domain types.Domain, err error) {
 	genesisValidatorsRoot := types.Root(common.HexToHash(genesisValidatorsRootHex))
 	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
-	if err != nil || len(forkVersionBytes) > 4 {
+	if err != nil || len(forkVersionBytes) != 4 {
 		return domain, errInvalidForkVersion
 	}
 	var forkVersion [4]byte


### PR DESCRIPTION
## 📝 Summary

If a custom genesis fork version that's fewer than 4 bytes (*e.g.*, `-genesis-fork-version 0xabcd`) is specified, the missing bytes will be filled with "random" bytes (*e.g.*, `0xabcd6364`). This PR will return an error if the fork version isn't exactly 4 bytes. Previously, it only returned an error if it was greater than 4 bytes.

## ⛱ Motivation and Context

Fixes #277.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
