### PR TITLE
Skip blockhash validation if version is not bellatrix

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -22,10 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	bellatrix = "bellatrix"
-)
-
 var (
 	errNoRelays                  = errors.New("no relays")
 	errInvalidSlot               = errors.New("invalid slot")
@@ -547,7 +543,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 			}
 
 			// Ensure the response blockhash matches the response block
-			if responsePayload.Version == bellatrix {
+			if responsePayload.Version == types.VersionString(config.ForkVersion) {
 				calculatedBlockHash, err := types.CalculateHash(responsePayload.Data)
 				if err != nil {
 					log.WithError(err).Error("could not calculate block hash")


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
 This change ignores the block hash validation for future versions of `SignedBlindedBeaconBlock` (after bellatrix)

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For the upcoming Capella and EIP-4844 upgrade this would break block hash validation as new fields will be introduced that is not included in the block hash calculation.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
