### PR TITLE
Prellocate map

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -314,8 +314,8 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	result := bidResp{}                           // the final response, containing the highest bid (if any)
-	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a specific blockHash
+	result := bidResp{}                                          // the final response, containing the highest bid (if any)
+	relays := make(map[BlockHashHex][]RelayEntry, len(m.relays)) // relays that sent the bid for a specific blockHash
 
 	// Call the relays
 	var mu sync.Mutex


### PR DESCRIPTION
## 📝 Summary

Preallocate map when we know the final size beforehand

## ⛱ Motivation and Context

Improve performance, but probably only when using many relays. 

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
