### PR TITLE
Future-proof CI (getting the version)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    # tags:
+    #   - 'v*'
 
 permissions:
   contents: write
@@ -18,8 +18,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get tag version
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Print version
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
 
       - name: Extract metadata (tags, labels) for Docker images
         id: meta
@@ -29,9 +33,9 @@ jobs:
           tags: |
             type=sha
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(steps.vars.outputs.tag, '-') }}
-            type=semver,pattern={{major}},enable=${{ !contains(steps.vars.outputs.tag, '-') }}
-            type=raw,value=latest,enable=${{ !contains(steps.vars.outputs.tag, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(env.RELEASE_VERSION, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(env.RELEASE_VERSION, '-') }}
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
 
       - name: Extract metadata (tags, labels) for portable Docker images
         id: meta-portable
@@ -42,140 +46,140 @@ jobs:
             type=sha
             type=semver,pattern={{version}},suffix=-portable
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          build-args: |
-            VERSION=${{ steps.vars.outputs.tag }}
-            CGO_CFLAGS=
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  #     - name: Build and push
+  #       uses: docker/build-push-action@v3
+  #       with:
+  #         context: .
+  #         push: true
+  #         build-args: |
+  #           VERSION=${{ env.RELEASE_VERSION }}
+  #           CGO_CFLAGS=
+  #         platforms: linux/amd64,linux/arm64
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Build and push portable
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          build-args: |
-            VERSION=${{ steps.vars.outputs.tag }}
-            CGO_CFLAGS=-O -D__BLST_PORTABLE__
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-portable.outputs.tags }}
-          labels: ${{ steps.meta-portable.outputs.labels }}
+  #     - name: Build and push portable
+  #       uses: docker/build-push-action@v3
+  #       with:
+  #         context: .
+  #         push: true
+  #         build-args: |
+  #           VERSION=${{ env.RELEASE_VERSION }}
+  #           CGO_CFLAGS=-O -D__BLST_PORTABLE__
+  #         platforms: linux/amd64,linux/arm64
+  #         tags: ${{ steps.meta-portable.outputs.tags }}
+  #         labels: ${{ steps.meta-portable.outputs.labels }}
 
-  build-linux-windows:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Fetch all tags
-        run: git fetch --force --tags
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - name: Install cross-compiler for linux/arm64 and windows
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu gcc-mingw-w64
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --skip-publish --config .goreleaser-linux_windows.yaml --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload
-        uses: actions/upload-artifact@v3
-        with:
-          name: mev-boost-linux_windows
-          path: |
-            dist/mev-boost*.tar.gz
-            dist/mev-boost*.txt
+  # build-linux-windows:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Fetch all tags
+  #       run: git fetch --force --tags
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: 1.19
+  #     - name: Install cross-compiler for linux/arm64 and windows
+  #       run: sudo apt-get -y install gcc-aarch64-linux-gnu gcc-mingw-w64
+  #     - name: Run GoReleaser
+  #       uses: goreleaser/goreleaser-action@v3
+  #       with:
+  #         distribution: goreleaser
+  #         version: latest
+  #         args: release --skip-publish --config .goreleaser-linux_windows.yaml --rm-dist
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Upload
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: mev-boost-linux_windows
+  #         path: |
+  #           dist/mev-boost*.tar.gz
+  #           dist/mev-boost*.txt
 
-  build-darwin:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Fetch all tags
-        run: git fetch --force --tags
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --skip-publish --config .goreleaser-darwin.yaml --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload
-        uses: actions/upload-artifact@v3
-        with:
-          name: mev-boost-darwin
-          path: |
-            dist/mev-boost*.tar.gz
-            dist/mev-boost*.txt
+  # build-darwin:
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Fetch all tags
+  #       run: git fetch --force --tags
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: 1.19
+  #     - name: Run GoReleaser
+  #       uses: goreleaser/goreleaser-action@v3
+  #       with:
+  #         distribution: goreleaser
+  #         version: latest
+  #         args: release --skip-publish --config .goreleaser-darwin.yaml --rm-dist
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Upload
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: mev-boost-darwin
+  #         path: |
+  #           dist/mev-boost*.tar.gz
+  #           dist/mev-boost*.txt
 
-  release:
-    needs: [build-linux-windows, build-darwin]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Fetch all tags
-        run: git fetch --force --tags
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - name: Make directories
-        run: |
-          mkdir -p ./build/linux_windows
-          mkdir -p ./build/darwin
-      - name: Download Linux and Windows binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: mev-boost-linux_windows
-          path: ./build/linux_windows
-      - name: Download Darwin binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: mev-boost-darwin
-          path: ./build/darwin
-      - name: Merge checksum file
-        run: |
-          cd ./build
-          cat ./darwin/mev-boost*checksums.txt >> checksums.txt
-          cat ./linux_windows/mev-boost*checksums.txt >> checksums.txt
-          rm ./darwin/mev-boost*checksums.txt
-          rm ./linux_windows/mev-boost*checksums.txt
-      - name: Release
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          args: release --config .goreleaser-release.yaml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # release:
+  #   needs: [build-linux-windows, build-darwin]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Fetch all tags
+  #       run: git fetch --force --tags
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: 1.19
+  #     - name: Make directories
+  #       run: |
+  #         mkdir -p ./build/linux_windows
+  #         mkdir -p ./build/darwin
+  #     - name: Download Linux and Windows binaries
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: mev-boost-linux_windows
+  #         path: ./build/linux_windows
+  #     - name: Download Darwin binaries
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: mev-boost-darwin
+  #         path: ./build/darwin
+  #     - name: Merge checksum file
+  #       run: |
+  #         cd ./build
+  #         cat ./darwin/mev-boost*checksums.txt >> checksums.txt
+  #         cat ./linux_windows/mev-boost*checksums.txt >> checksums.txt
+  #         rm ./darwin/mev-boost*checksums.txt
+  #         rm ./linux_windows/mev-boost*checksums.txt
+  #     - name: Release
+  #       uses: goreleaser/goreleaser-action@v3
+  #       with:
+  #         args: release --config .goreleaser-release.yaml
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    # tags:
-    #   - 'v*'
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -46,140 +46,140 @@ jobs:
             type=sha
             type=semver,pattern={{version}},suffix=-portable
 
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Build and push
-  #       uses: docker/build-push-action@v3
-  #       with:
-  #         context: .
-  #         push: true
-  #         build-args: |
-  #           VERSION=${{ env.RELEASE_VERSION }}
-  #           CGO_CFLAGS=
-  #         platforms: linux/amd64,linux/arm64
-  #         tags: ${{ steps.meta.outputs.tags }}
-  #         labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ env.RELEASE_VERSION }}
+            CGO_CFLAGS=
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-  #     - name: Build and push portable
-  #       uses: docker/build-push-action@v3
-  #       with:
-  #         context: .
-  #         push: true
-  #         build-args: |
-  #           VERSION=${{ env.RELEASE_VERSION }}
-  #           CGO_CFLAGS=-O -D__BLST_PORTABLE__
-  #         platforms: linux/amd64,linux/arm64
-  #         tags: ${{ steps.meta-portable.outputs.tags }}
-  #         labels: ${{ steps.meta-portable.outputs.labels }}
+      - name: Build and push portable
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ env.RELEASE_VERSION }}
+            CGO_CFLAGS=-O -D__BLST_PORTABLE__
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta-portable.outputs.tags }}
+          labels: ${{ steps.meta-portable.outputs.labels }}
 
-  # build-linux-windows:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Fetch all tags
-  #       run: git fetch --force --tags
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: 1.19
-  #     - name: Install cross-compiler for linux/arm64 and windows
-  #       run: sudo apt-get -y install gcc-aarch64-linux-gnu gcc-mingw-w64
-  #     - name: Run GoReleaser
-  #       uses: goreleaser/goreleaser-action@v3
-  #       with:
-  #         distribution: goreleaser
-  #         version: latest
-  #         args: release --skip-publish --config .goreleaser-linux_windows.yaml --rm-dist
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Upload
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: mev-boost-linux_windows
-  #         path: |
-  #           dist/mev-boost*.tar.gz
-  #           dist/mev-boost*.txt
+  build-linux-windows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Install cross-compiler for linux/arm64 and windows
+        run: sudo apt-get -y install gcc-aarch64-linux-gnu gcc-mingw-w64
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --skip-publish --config .goreleaser-linux_windows.yaml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: mev-boost-linux_windows
+          path: |
+            dist/mev-boost*.tar.gz
+            dist/mev-boost*.txt
 
-  # build-darwin:
-  #   runs-on: macos-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Fetch all tags
-  #       run: git fetch --force --tags
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: 1.19
-  #     - name: Run GoReleaser
-  #       uses: goreleaser/goreleaser-action@v3
-  #       with:
-  #         distribution: goreleaser
-  #         version: latest
-  #         args: release --skip-publish --config .goreleaser-darwin.yaml --rm-dist
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Upload
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: mev-boost-darwin
-  #         path: |
-  #           dist/mev-boost*.tar.gz
-  #           dist/mev-boost*.txt
+  build-darwin:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --skip-publish --config .goreleaser-darwin.yaml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: mev-boost-darwin
+          path: |
+            dist/mev-boost*.tar.gz
+            dist/mev-boost*.txt
 
-  # release:
-  #   needs: [build-linux-windows, build-darwin]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Fetch all tags
-  #       run: git fetch --force --tags
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: 1.19
-  #     - name: Make directories
-  #       run: |
-  #         mkdir -p ./build/linux_windows
-  #         mkdir -p ./build/darwin
-  #     - name: Download Linux and Windows binaries
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: mev-boost-linux_windows
-  #         path: ./build/linux_windows
-  #     - name: Download Darwin binaries
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: mev-boost-darwin
-  #         path: ./build/darwin
-  #     - name: Merge checksum file
-  #       run: |
-  #         cd ./build
-  #         cat ./darwin/mev-boost*checksums.txt >> checksums.txt
-  #         cat ./linux_windows/mev-boost*checksums.txt >> checksums.txt
-  #         rm ./darwin/mev-boost*checksums.txt
-  #         rm ./linux_windows/mev-boost*checksums.txt
-  #     - name: Release
-  #       uses: goreleaser/goreleaser-action@v3
-  #       with:
-  #         args: release --config .goreleaser-release.yaml
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    needs: [build-linux-windows, build-darwin]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Make directories
+        run: |
+          mkdir -p ./build/linux_windows
+          mkdir -p ./build/darwin
+      - name: Download Linux and Windows binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: mev-boost-linux_windows
+          path: ./build/linux_windows
+      - name: Download Darwin binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: mev-boost-darwin
+          path: ./build/darwin
+      - name: Merge checksum file
+        run: |
+          cd ./build
+          cat ./darwin/mev-boost*checksums.txt >> checksums.txt
+          cat ./linux_windows/mev-boost*checksums.txt >> checksums.txt
+          rm ./darwin/mev-boost*checksums.txt
+          rm ./linux_windows/mev-boost*checksums.txt
+      - name: Release
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          args: release --config .goreleaser-release.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,7 +32,7 @@ go run . -mainnet -relay-check -debug -min-bid 0.12345 \
     -relay https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io \
     -relay https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com \
     -relay-monitor https://relay-monitor1.example.com \
-    -relay-monitor https://relay-monitor2.example.com \
+    -relay-monitor https://relay-monitor2.example.com
 
 # Call the status endpoint
 curl localhost:18550/eth/v1/builder/status

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,14 +23,16 @@ go mod tidy
 git status # should be no changes
 
 # Start mev-boost with relay check and -relays
-go run . -mainnet -relay-check -relays https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io,https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com -debug
+go run . -mainnet -relay-check -min-bid 0.12345 -debug -relays https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io,https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com -relay-monitors https://relay-monitor1.example.com,https://relay-monitor2.example.com
 
 # Start mev-boost with relay check and multiple -relay flags
-go run . -mainnet -relay-check -debug \
+go run . -mainnet -relay-check -debug -min-bid 0.12345 \
     -relay https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net \
     -relay https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com \
     -relay https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io \
-    -relay https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com
+    -relay https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com \
+    -relay-monitor https://relay-monitor1.example.com \
+    -relay-monitor https://relay-monitor2.example.com \
 
 # Call the status endpoint
 curl localhost:18550/eth/v1/builder/status


### PR DESCRIPTION
## 📝 Summary

* Upgraded Github CI with future-proof versions (previous method is [going to be deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* Added more mev-boost flags to the release guide

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
