### PR TITLE
Add support for relay weights

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -76,7 +76,7 @@ var log = logrus.NewEntry(logrus.New())
 // Main starts the mev-boost cli
 func Main() {
 	// process repeatable flags
-	flag.Var(&relays, "relay", "a single relay, can be specified multiple times")
+	flag.Var(&relays, "relay", "a single relay (optional weight can be defined using weight#relayURL), can be specified multiple times")
 	flag.Var(&relayMonitors, "relay-monitor", "a single relay monitor, can be specified multiple times")
 
 	// parse flags and get started
@@ -154,7 +154,7 @@ func Main() {
 	}
 	log.Infof("using %d relays", len(relays))
 	for index, relay := range relays {
-		log.Infof("relay #%d: %s", index+1, relay.String())
+		log.Infof("relay #%d: %s - weight: %f", index+1, relay.String(), relay.Weight)
 	}
 
 	// For backwards compatibility with the -relay-monitors flag.

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -348,6 +348,56 @@ func TestGetHeader(t *testing.T) {
 		require.Equal(t, types.IntToU256(12347), resp.Data.Message.Value)
 	})
 
+	t.Run("Use header with lower value if weighted higher", func(t *testing.T) {
+		// Create backend and register 3 relays.
+		backend := newTestBackend(t, 3, time.Second)
+
+		// Set weights for relays.
+		backend.boost.relays[0].Weight = 1
+		backend.boost.relays[1].Weight = 0.9
+		backend.boost.relays[2].Weight = 2
+
+		// First relay will return signed response with value 123450 * 1 = 123450.
+		backend.relays[0].GetHeaderResponse = backend.relays[0].MakeGetHeaderResponse(
+			123450,
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
+		)
+
+		// First relay will return signed response with value 137180 * 0.9 = 123462.
+		backend.relays[1].GetHeaderResponse = backend.relays[1].MakeGetHeaderResponse(
+			137180,
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
+		)
+
+		// First relay will return signed response with value 61740 * 2 = 123480.
+		backend.relays[2].GetHeaderResponse = backend.relays[2].MakeGetHeaderResponse(
+			61740,
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
+		)
+
+		// Run the request.
+		rr := backend.request(t, http.MethodGet, path, nil)
+
+		// Each relay must have received the request.
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
+		require.Equal(t, 1, backend.relays[1].GetRequestCount(path))
+		require.Equal(t, 1, backend.relays[2].GetRequestCount(path))
+
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+		// Highest value should be 12347, i.e. second relay.
+		resp := new(types.GetHeaderResponse)
+		err := json.Unmarshal(rr.Body.Bytes(), resp)
+		require.NoError(t, err)
+		require.Equal(t, types.IntToU256(61740), resp.Data.Message.Value)
+	})
+
 	t.Run("Use header with lowest blockhash if same value", func(t *testing.T) {
 		// Create backend and register 3 relays.
 		backend := newTestBackend(t, 3, time.Second)

--- a/server/utils.go
+++ b/server/utils.go
@@ -123,6 +123,7 @@ type bidResp struct {
 	response  types.GetHeaderResponse
 	blockHash string
 	relays    []RelayEntry
+	weighted  float64
 }
 
 // bidRespKey is used as key for the bids cache


### PR DESCRIPTION
## 📝 Summary

Adds support for weighting relays. This affects how mev-boost determines what header to follow.

## ⛱ Motivation and Context

It allows users to evaluate multiple relays but only accept some headers when the risk/benefit outweighs the risks. For example an user could try to avoid relay X due to arbitrary reasons (censorship, trust, etc), but may want to still accept headers from it when it pays 10 times more.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
