### PR TITLE
fix CI latest Docker image tagging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,7 @@ jobs:
           tags: |
             type=sha
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(env.RELEASE_VERSION, '-') }}
-            type=semver,pattern={{major}},enable=${{ !contains(env.RELEASE_VERSION, '-') }}
-            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
+            type=raw,value=latest,enable=false
 
       - name: Extract metadata (tags, labels) for portable Docker images
         id: meta-portable
@@ -45,6 +43,7 @@ jobs:
           tags: |
             type=sha
             type=semver,pattern={{version}},suffix=-portable
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## 📝 Summary

Fix CI overwriting the `latest` Docker image with both portable and non-portable images (as seen here in the latest release CI action: https://github.com/flashbots/mev-boost/actions/runs/3428613593/jobs/5713128560)

Currently, the `latest` image on Docker hub is the portable image.

This PR updates the Docker release CI step to do that explicitly.

Also removes pushing images for `:1` and `:1.4` when releasing `v1.4.0` (these image tags seem unnecessary and I'd opt for removing them from Docker hub, otherwise we should also add them for portable).

See also #412 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
