### PR TITLE
readme: remove docker latest-portable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,8 @@ We maintain a MEV-Boost Docker images at https://hub.docker.com/r/flashbots/mev-
 - Pull & run the latest image:
 
 ```bash
-# Get the default MEV-Boost image
+# Get the MEV-Boost image
 docker pull flashbots/mev-boost:latest
-
-# Get the portable MEV-Boost image
-docker pull flashbots/mev-boost:latest-portable
 
 # Run it
 docker run flashbots/mev-boost -help


### PR DESCRIPTION
## 📝 Summary

No longer applicable, that tag is now removed and the `latest` docker tag is now the portable build.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
