### PR TITLE
When building the docker, cache mod download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,13 @@ FROM golang:1.18 as builder
 ARG VERSION
 ARG CGO_CFLAGS
 WORKDIR /build
-ADD . /build/
+
+COPY go.mod ./
+COPY go.sum ./
+
+RUN go mod download
+
+ADD . .
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" -v -o mev-boost .
 
 FROM alpine


### PR DESCRIPTION
## 📝 Summary

Cache the mod download for a much faster docker image build.

## ⛱ Motivation and Context

Saves 2 minutes on consecutive builds if modules didn't change.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
