### PR TITLE
Drain body completely to reuse connection

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -63,7 +63,11 @@ func SendHTTPRequest(ctx context.Context, client http.Client, method, url string
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// drain body completely to reuse connection
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode == http.StatusNoContent {
 		return resp.StatusCode, nil


### PR DESCRIPTION
## 📝 Summary

Drain body completely to reuse connection

## ⛱ Motivation and Context

Reuse connections when possible

## 📚 References
> // The http Client and Transport guarantee that Body is always
	// non-nil, even on responses without a body or responses with
	// a zero-length body. **It is the caller's responsibility to
	// close Body. The default HTTP client's Transport may not
	// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
	// not read to completion and closed.**
https://pkg.go.dev/net/http#Response

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
