### PR TITLE
use Go v1.20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.19
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: ^1.20
           id: go
 
       - name: Ensure go mod tidy runs without changes
@@ -29,13 +29,13 @@ jobs:
           git diff-index --quiet HEAD
 
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@v0.3.1
+        run: go install mvdan.cc/gofumpt@v0.4.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
       - name: Lint
         run: make lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: ^1.20
       - name: Install cross-compiler for linux/arm64 and windows
         run: sudo apt-get -y install gcc-aarch64-linux-gnu gcc-mingw-w64
       - name: Run GoReleaser
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: ^1.20
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: ^1.20
       - name: Make directories
         run: |
           mkdir -p ./build/linux_windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
       CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
       CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ^1.20
         id: go
 
       - name: Checkout sources

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
+    - musttag
 
     #
     # Maybe fix later:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG VERSION
 ARG CGO_CFLAGS
 WORKDIR /build
@@ -10,7 +10,7 @@ COPY go.sum ./
 RUN go mod download
 
 ADD . .
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" -v -o mev-boost .
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION' -linkmode external -extldflags '-static'" -v -o mev-boost .
 
 FROM alpine
 RUN apk add --no-cache libstdc++ libc6-compat

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flashbots/mev-boost
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.10.25

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -181,20 +181,6 @@ func TestWebserverMaxHeaderSize(t *testing.T) {
 	backend.boost.srv.Close()
 }
 
-// Example good registerValidator payload
-var payloadRegisterValidator = types.SignedValidatorRegistration{
-	Message: &types.RegisterValidatorRequestMessage{
-		FeeRecipient: _HexToAddress("0xdb65fEd33dc262Fe09D9a2Ba8F80b329BA25f941"),
-		Timestamp:    1234356,
-		GasLimit:     278234191203,
-		Pubkey: _HexToPubkey(
-			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"),
-	},
-	// Signed by 0x4e343a647c5a5c44d76c2c58b63f02cdf3a9a0ec40f102ebc26363b4b1b95033
-	Signature: _HexToSignature(
-		"0x8209b5391cd69f392b1f02dbc03bab61f574bb6bb54bf87b59e2a85bdc0756f7db6a71ce1b41b727a1f46ccc77b213bf0df1426177b5b29926b39956114421eaa36ec4602969f6f6370a44de44a6bce6dae2136e5fb594cce2a476354264d1ea"),
-}
-
 func TestStatus(t *testing.T) {
 	t.Run("At least one relay is available", func(t *testing.T) {
 		backend := newTestBackend(t, 1, time.Second)


### PR DESCRIPTION
## 📝 Summary

Go v1.20.1 is the latest. Default to 1.20 for building and testing.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
