### PR TITLE
getPayload retry with 100ms timeout

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -118,6 +118,7 @@ func SendHTTPRequestWithRetries(ctx context.Context, client http.Client, method,
 		code, err = SendHTTPRequest(ctx, client, method, url, userAgent, payload, dst)
 		if err != nil {
 			log.WithError(err).Warn("error making request to relay, retrying")
+			time.Sleep(100 * time.Millisecond) // note: this timeout is only applied between retries, it does not delay the initial request!
 			continue
 		}
 		return code, nil


### PR DESCRIPTION
## 📝 Summary

Wait 100ms until getPayload retry for higher success rate

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
