### PR TITLE
Produce statically linked builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           build-args: |
             VERSION=${{ env.RELEASE_VERSION }}
             CGO_CFLAGS=
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v6
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -77,7 +77,7 @@ jobs:
           build-args: |
             VERSION=${{ env.RELEASE_VERSION }}
             CGO_CFLAGS=-O -D__BLST_PORTABLE__
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v6
           tags: ${{ steps.meta-portable.outputs.tags }}
           labels: ${{ steps.meta-portable.outputs.labels }}
 

--- a/.goreleaser-darwin.yaml
+++ b/.goreleaser-darwin.yaml
@@ -1,7 +1,13 @@
 project_name: mev-boost
 builds:
   - id: mev-boost-portable
+    tags:
+      - osusergo
+      - netgo
+    flags:
+      - -trimpath
     ldflags:
+      - -w -s
       - -X github.com/flashbots/mev-boost/config.Version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser-linux_windows.yaml
+++ b/.goreleaser-linux_windows.yaml
@@ -1,7 +1,15 @@
+# https://goreleaser.com/customization/builds/
 project_name: mev-boost
 builds:
   - id: mev-boost-portable
+    tags:
+      - osusergo
+      - netgo
+    flags:
+      - -trimpath
     ldflags:
+      - -extldflags=-static
+      - -w -s
       - -X github.com/flashbots/mev-boost/config.Version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ COPY go.sum ./
 RUN go mod download
 
 ADD . .
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION' -linkmode external -extldflags '-static'" -v -o mev-boost .
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_CFLAGS="$CGO_CFLAGS" GOOS=linux go build \
+    -tags osusergo,netgo \
+    -trimpath \
+    -ldflags "-extldflags=-static -w -s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" \
+    -v \
+    -o mev-boost .
 
 FROM alpine
-RUN apk add --no-cache libstdc++ libc6-compat
 WORKDIR /app
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/mev-boost /app/mev-boost

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,21 @@
 VERSION ?= $(shell git describe --tags --always --dirty="-dev")
 DOCKER_REPO := flashbots/mev-boost
 
+# Force os/user & net/go to be pure Go.
+GO_BUILD_FLAGS += -tags osusergo,netgo
+# Remove all file system paths from the executable.
+GO_BUILD_FLAGS += -trimpath
+# Make the build more verbose.
+GO_BUILD_FLAGS += -v
+
+# Set linker flags to:
+#   -w: disables DWARF debugging information.
+GO_BUILD_LDFLAGS += -w
+#   -s: disables symbol table information.
+GO_BUILD_LDFLAGS += -s
+#   -X: sets the value of the symbol.
+GO_BUILD_LDFLAGS += -X 'github.com/flashbots/mev-boost/config.Version=$(VERSION)'
+
 .PHONY: all
 all: build
 
@@ -10,23 +25,24 @@ v:
 
 .PHONY: build
 build:
-	go build -tags osusergo,netgo -trimpath -ldflags "-w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+	$(EXTRA_ENV) go build $(GO_BUILD_FLAGS) -ldflags "$(GO_BUILD_LDFLAGS)" -o mev-boost .
 
 .PHONY: build-portable
-build-portable:
-	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -tags osusergo,netgo -trimpath -ldflags "-w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+build-portable: EXTRA_ENV = CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+build-portable: build
 
 .PHONY: build-static
-build-static:
-	go build -tags osusergo,netgo -trimpath -ldflags "-extldflags=-static -w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+build-static: GO_BUILD_LDFLAGS += "-extldflags=-static"
+build-static: build
 
 .PHONY: build-portable-static
-build-portable-static:
-	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -tags osusergo,netgo -trimpath -ldflags "-extldflags=-static -w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+build-portable-static: EXTRA_ENV = CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+build-portable-static: GO_BUILD_LDFLAGS += -extldflags=-static
+build-portable-static: build
 
 .PHONY: build-testcli
 build-testcli:
-	go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o test-cli ./cmd/test-cli
+	go build $(GO_BUILD_FLAGS) -ldflags "$(GO_BUILD_LDFLAGS)" -o test-cli ./cmd/test-cli
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty="-dev")
 DOCKER_REPO := flashbots/mev-boost
 
-# Force os/user & net/go to be pure Go.
+# Force os/user & net to be pure Go.
 GO_BUILD_FLAGS += -tags osusergo,netgo
 # Remove all file system paths from the executable.
 GO_BUILD_FLAGS += -trimpath

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,19 @@ v:
 
 .PHONY: build
 build:
-	go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+	go build -tags osusergo,netgo -trimpath -ldflags "-w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
 
 .PHONY: build-portable
 build-portable:
-	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -trimpath -ldflags "-s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -tags osusergo,netgo -trimpath -ldflags "-w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+
+.PHONY: build-static
+build-static:
+	go build -tags osusergo,netgo -trimpath -ldflags "-extldflags=-static -w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
+
+.PHONY: build-portable-static
+build-portable-static:
+	CGO_CFLAGS="-O -D__BLST_PORTABLE__" go build -tags osusergo,netgo -trimpath -ldflags "-extldflags=-static -w -s -X 'github.com/flashbots/mev-boost/config.Version=${VERSION}'" -v -o mev-boost .
 
 .PHONY: build-testcli
 build-testcli:


### PR DESCRIPTION
## 📝 Summary

* Added `make build-static` and `make build-portable-static` (to not change default `make build` behaviour, and the static builds don't work on macOS)
* Creating statically linked binaries in Docker
* Creating statically linked binaries in goreleaser

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
