### PR TITLE
Removed two references to the flashbot relay

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ Alternatively, run mev-boost without build step:
 ```bash
 go run . -h
 
-# Run mev-boost pointed at our goerli builder+relay
-go run . -goerli -relay-check -relays https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@builder-relay-goerli.flashbots.net
+# Run mev-boost
+./mev-boost -goerli -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
 Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-goerli`/`-sepolia`).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PoS node operators must run three pieces of software: a validator client, a cons
 
 Relays aggregate blocks from **multiple** builders in order to select the block with the highest fees. One instance of MEV-boost can be configured by a validator to connect to **multiple** relays. The consensus layer client of a validator proposes the most profitable block received from MEV-boost to the Ethereum network for attestation and block inclusion.
 
-A MEV-Boost security assessment was conducted on 2022-06-20 by [lotusbumi](https://github.com/lotusbumi). Additional audits of surrounding infrastructure, such as the Flashbots Relay, are currently underway. Additional information can be found in the [Security](#security) section of this repository.
+A MEV-Boost security assessment was conducted on 2022-06-20 by [lotusbumi](https://github.com/lotusbumi). Additional information can be found in the [Security](#security) section of this repository.
 
 
 ![MEV-Boost service integration overview](https://raw.githubusercontent.com/flashbots/mev-boost/main/docs/mev-boost-integration-overview.png)
@@ -30,7 +30,6 @@ MEV-Boost is a piece of software that any PoS Ethereum node operator (including 
 
 See also:
 
-* [boost.flashbots.net](https://boost.flashbots.net)
 * [MEV-Boost Docker images](https://hub.docker.com/r/flashbots/mev-boost)
 * [Wiki](https://github.com/flashbots/mev-boost/wiki)
 * [MEV-Boost relay source code](https://github.com/flashbots/mev-boost-relay)

--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ See also:
 
 * [MEV-Boost Docker images](https://hub.docker.com/r/flashbots/mev-boost)
 * [Wiki](https://github.com/flashbots/mev-boost/wiki)
-* [MEV-Boost relay source code](https://github.com/flashbots/mev-boost-relay)
 * Specs:
   * [Builder API](https://ethereum.github.io/builder-specs)
-  * [MEV-Boost Relay API](https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5)
 
 ---
 

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -64,7 +64,7 @@ Env & defaults:
 ### Run mev-boost
 
 ```
-./mev-boost -kiln -relays https://0xb5246e299aeb782fbc7c91b41b3284245b1ed5206134b0028b81dfb974e5900616c67847c2354479934fc4bb75519ee1@builder-relay-kiln.flashbots.net
+./mev-boost -goerli -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
 ### Run beacon node


### PR DESCRIPTION

## 📝 Summary

Change to README.md which removes two references to the flashbots relay

## ⛱ Motivation and Context

Proposing to do this change to have equal exposure for other relays in the readme


## 📚 References

N/A

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
