### PR TITLE
Do not allow relays to have point-at-infinity pubkey

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -6,4 +6,4 @@ import "fmt"
 var ErrMissingRelayPubkey = fmt.Errorf("missing relay public key")
 
 // ErrPointAtInfinityPubkey is returned if a new RelayEntry URL has an all-zero public key.
-var ErrPointAtInfinityPubkey = fmt.Errorf("relay public key cannot be the point at infinity")
+var ErrPointAtInfinityPubkey = fmt.Errorf("relay public key cannot be the point-at-infinity")

--- a/server/errors.go
+++ b/server/errors.go
@@ -2,5 +2,8 @@ package server
 
 import "fmt"
 
-// ErrMissingRelayPubkey is returned if a new RelayEntry URL has no public key
+// ErrMissingRelayPubkey is returned if a new RelayEntry URL has no public key.
 var ErrMissingRelayPubkey = fmt.Errorf("missing relay public key")
+
+// ErrPointAtInfinityPubkey is returned if a new RelayEntry URL has an all-zero public key.
+var ErrPointAtInfinityPubkey = fmt.Errorf("relay public key cannot be the point at infinity")

--- a/server/relay_entry.go
+++ b/server/relay_entry.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"net/url"
 	"strings"
 
@@ -41,8 +42,19 @@ func NewRelayEntry(relayURL string) (entry RelayEntry, err error) {
 		return entry, ErrMissingRelayPubkey
 	}
 
+	// Convert the username string to a public key.
 	err = entry.PublicKey.UnmarshalText([]byte(entry.URL.User.Username()))
-	return entry, err
+	if err != nil {
+		return entry, err
+	}
+
+	// Check if the public key is the point at infinity.
+	pointAtInfinity := [48]byte{}
+	if bytes.Equal(entry.PublicKey[:], pointAtInfinity[:]) {
+		return entry, ErrPointAtInfinityPubkey
+	}
+
+	return entry, nil
 }
 
 // RelayEntriesToStrings returns the string representation of a list of relay entries

--- a/server/relay_entry.go
+++ b/server/relay_entry.go
@@ -48,7 +48,7 @@ func NewRelayEntry(relayURL string) (entry RelayEntry, err error) {
 		return entry, err
 	}
 
-	// Check if the public key is the point at infinity.
+	// Check if the public key is the point-at-infinity.
 	pointAtInfinity := [48]byte{}
 	if bytes.Equal(entry.PublicKey[:], pointAtInfinity[:]) {
 		return entry, ErrPointAtInfinityPubkey

--- a/server/relay_entry.go
+++ b/server/relay_entry.go
@@ -8,6 +8,9 @@ import (
 	"github.com/flashbots/go-boost-utils/types"
 )
 
+// The point-at-infinity is 48 zero bytes.
+var pointAtInfinityPubkey = [48]byte{}
+
 // RelayEntry represents a relay that mev-boost connects to.
 type RelayEntry struct {
 	PublicKey types.PublicKey
@@ -49,8 +52,7 @@ func NewRelayEntry(relayURL string) (entry RelayEntry, err error) {
 	}
 
 	// Check if the public key is the point-at-infinity.
-	pointAtInfinity := [48]byte{}
-	if bytes.Equal(entry.PublicKey[:], pointAtInfinity[:]) {
+	if bytes.Equal(entry.PublicKey[:], pointAtInfinityPubkey[:]) {
 		return entry, ErrPointAtInfinityPubkey
 	}
 

--- a/server/relay_entry_test.go
+++ b/server/relay_entry_test.go
@@ -63,7 +63,7 @@ func TestParseRelaysURLs(t *testing.T) {
 			expectedURL:       "https://" + publicKey.String() + "@12.345.678:9999",
 		},
 		{
-			name:        "Relay URL with invalid pubkey",
+			name:        "Relay URL with invalid public key",
 			relayURL:    "http://0x123456@foo.com",
 			expectedErr: types.ErrLength,
 		},

--- a/server/relay_entry_test.go
+++ b/server/relay_entry_test.go
@@ -68,7 +68,7 @@ func TestParseRelaysURLs(t *testing.T) {
 			expectedErr: types.ErrLength,
 		},
 		{
-			name:        "Relay URL with point at infinity public key",
+			name:        "Relay URL with point-at-infinity public key",
 			relayURL:    "http://0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000@foo.com",
 			expectedErr: ErrPointAtInfinityPubkey,
 		},

--- a/server/relay_entry_test.go
+++ b/server/relay_entry_test.go
@@ -23,61 +23,58 @@ func TestParseRelaysURLs(t *testing.T) {
 		expectedURL       string
 	}{
 		{
-			name:     "Relay URL with protocol scheme",
-			relayURL: fmt.Sprintf("http://%s@foo.com", publicKey.String()),
-
+			name:              "Relay URL with protocol scheme",
+			relayURL:          fmt.Sprintf("http://%s@foo.com", publicKey.String()),
 			expectedURI:       "http://foo.com",
 			expectedPublicKey: publicKey.String(),
 			expectedURL:       fmt.Sprintf("http://%s@foo.com", publicKey.String()),
 		},
 		{
-			name:     "Relay URL without protocol scheme, without public key",
-			relayURL: "foo.com",
-
+			name:        "Relay URL without protocol scheme, without public key",
+			relayURL:    "foo.com",
 			expectedErr: ErrMissingRelayPubkey,
 		},
 		{
-			name:     "Relay URL without protocol scheme and with public key",
-			relayURL: publicKey.String() + "@foo.com",
-
+			name:              "Relay URL without protocol scheme and with public key",
+			relayURL:          publicKey.String() + "@foo.com",
 			expectedURI:       "http://foo.com",
 			expectedPublicKey: publicKey.String(),
 			expectedURL:       "http://" + publicKey.String() + "@foo.com",
 		},
 		{
-			name:     "Relay URL with public key host and port",
-			relayURL: publicKey.String() + "@foo.com:9999",
-
+			name:              "Relay URL with public key host and port",
+			relayURL:          publicKey.String() + "@foo.com:9999",
 			expectedURI:       "http://foo.com:9999",
 			expectedPublicKey: publicKey.String(),
 			expectedURL:       "http://" + publicKey.String() + "@foo.com:9999",
 		},
 		{
-			name:     "Relay URL with IP and port",
-			relayURL: publicKey.String() + "@12.345.678:9999",
-
+			name:              "Relay URL with IP and port",
+			relayURL:          publicKey.String() + "@12.345.678:9999",
 			expectedURI:       "http://12.345.678:9999",
 			expectedPublicKey: publicKey.String(),
 			expectedURL:       "http://" + publicKey.String() + "@12.345.678:9999",
 		},
 		{
-			name:     "Relay URL with https IP and port",
-			relayURL: "https://" + publicKey.String() + "@12.345.678:9999",
-
+			name:              "Relay URL with https IP and port",
+			relayURL:          "https://" + publicKey.String() + "@12.345.678:9999",
 			expectedURI:       "https://12.345.678:9999",
 			expectedPublicKey: publicKey.String(),
 			expectedURL:       "https://" + publicKey.String() + "@12.345.678:9999",
 		},
 		{
-			name:     "Invalid relay public key",
-			relayURL: "http://0x123456@foo.com",
-
+			name:        "Relay URL with invalid pubkey",
+			relayURL:    "http://0x123456@foo.com",
 			expectedErr: types.ErrLength,
 		},
 		{
-			name:     "Relay URL with query arg",
-			relayURL: fmt.Sprintf("http://%s@foo.com?id=foo&bar=1", publicKey.String()),
-
+			name:        "Relay URL with point at infinity public key",
+			relayURL:    "http://0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000@foo.com",
+			expectedErr: ErrPointAtInfinityPubkey,
+		},
+		{
+			name:              "Relay URL with query arg",
+			relayURL:          fmt.Sprintf("http://%s@foo.com?id=foo&bar=1", publicKey.String()),
 			expectedURI:       "http://foo.com?id=foo&bar=1",
 			expectedPublicKey: publicKey.String(),
 			expectedURL:       fmt.Sprintf("http://%s@foo.com?id=foo&bar=1", publicKey.String()),


### PR DESCRIPTION
## 📝 Summary

* Return an error if a relay is configured with the point-at-infinity (all-zero) pubkey.
* Delete blank lines in test cases (just a nit picky thing I want to fix).
* Rename a test case for consistency:
  * From: "Invalid relay public key"
  * To: "Relay URL with invalid public key"

## ⛱ Motivation and Context

@asanso pointed out that if a relay were configured with the point-at-infinity public key, it could essentially bypass signature verification checks when receiving bids. In practice, this isn't a problem. A user would need to configure mev-boost with this and there's already a trusted relationship with relays (_i.e.,_ we trust them to only send valid bids/payloads). But I do think it's a good situation to avoid and that's why I'm making this PR.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
