### PR TITLE
only run github ci checks once

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,9 @@ name: Linting
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,9 @@ name: Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## 📝 Summary

Before they were always run twice (once for push and once for PR). This PR makes the checks run only once.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
