### PR TITLE
Replace go-boost-utils types with attestant types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/flashbots/go-utils v0.4.8
 	github.com/gorilla/mux v1.8.0
 	github.com/holiman/uint256 v1.2.2
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2
 )
@@ -39,7 +40,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/attestantio/go-builder-client v0.2.8 h1:Z4FSbzSWz6sB3QJn9ckjzFDcTBJ1CCxpQ1B2gau9YO8=
-github.com/attestantio/go-builder-client v0.2.8/go.mod h1:hEC/cKf5HGLSC0gpo/uqZ7xbWLRu14ILi51o1+HXZEE=
 github.com/attestantio/go-eth2-client v0.15.8 h1:ndeqKacjT3vDD8yJVGe7CGmyrhVbQleBCYIPsULzGMM=
 github.com/attestantio/go-eth2-client v0.15.8/go.mod h1:PLRKnILnr63V3yl2VagBqnhVRFBWc0V+JhQSsXQaSwQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
@@ -142,8 +140,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/ferranbt/fastssz v0.1.2/go.mod h1:X5UPrE2u1UJjxHA8X54u04SBwdAQjG2sFtWs39YxyWs=
 github.com/ferranbt/fastssz v0.1.3 h1:ZI+z3JH05h4kgmFXdHuR1aWYsgrg7o+Fw7/NCzM16Mo=
 github.com/ferranbt/fastssz v0.1.3/go.mod h1:0Y9TEd/9XuFlh7mskMPfXiI2Dkw4Ddg9EyXt1W7MRvE=
-github.com/flashbots/go-boost-utils v1.5.0 h1:9ObO7uphj2zjXl2Fl6GZ0y1EEIpjbBxQB7DUcngk6Gk=
-github.com/flashbots/go-boost-utils v1.5.0/go.mod h1:0/LeipVcFZTJ/wdAhBaDW8AASTsw9gVxvTllBtHgeWg=
 github.com/flashbots/go-utils v0.4.8 h1:WDJXryrqShGq4HFe+p1kGjObXSqzT7Sy/+9YvFpr5tM=
 github.com/flashbots/go-utils v0.4.8/go.mod h1:dBmSv4Cpqij4xKP50bdisAvFIo4/EgsY97BMpVjPzr0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/server/errors.go
+++ b/server/errors.go
@@ -7,3 +7,6 @@ var ErrMissingRelayPubkey = fmt.Errorf("missing relay public key")
 
 // ErrPointAtInfinityPubkey is returned if a new RelayEntry URL has an all-zero public key.
 var ErrPointAtInfinityPubkey = fmt.Errorf("relay public key cannot be the point-at-infinity")
+
+// ErrInvalidLengthPubkey is returned if a new RelayEntry URL has an invalid length public key.
+var ErrInvalidLengthPubkey = fmt.Errorf("relay public key is not the correct length")

--- a/server/mock_types.go
+++ b/server/mock_types.go
@@ -1,8 +1,9 @@
 package server
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/flashbots/go-boost-utils/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,41 +20,61 @@ func _HexToBytes(hex string) []byte {
 }
 
 // _HexToHash converts a hexadecimal string to an Ethereum hash
-func _HexToHash(s string) (ret types.Hash) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToHash(s string) (ret phase0.Hash32) {
+	retBytes, err := hexutil.Decode(s)
 	if err != nil {
 		testLog.Error(err, " _HexToHash: ", s)
 		panic(err)
 	}
+	if len(retBytes) != len(ret) {
+		testLog.Error(" _HexToHash: invalid length", len(retBytes))
+		panic(err)
+	}
+	copy(ret[:], retBytes)
 	return ret
 }
 
 // _HexToAddress converts a hexadecimal string to an Ethereum address
-func _HexToAddress(s string) (ret types.Address) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToAddress(s string) (ret bellatrix.ExecutionAddress) {
+	retBytes, err := hexutil.Decode(s)
 	if err != nil {
 		testLog.Error(err, " _HexToAddress: ", s)
 		panic(err)
 	}
+	if len(retBytes) != len(ret) {
+		testLog.Error(" _HexToAddress: invalid length", len(retBytes))
+		panic(err)
+	}
+	copy(ret[:], retBytes)
 	return ret
 }
 
 // _HexToPubkey converts a hexadecimal string to a BLS Public Key
-func _HexToPubkey(s string) (ret types.PublicKey) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToPubkey(s string) (ret phase0.BLSPubKey) {
+	retBytes, err := hexutil.Decode(s)
 	if err != nil {
 		testLog.Error(err, " _HexToPubkey: ", s)
 		panic(err)
 	}
+	if len(retBytes) != len(ret) {
+		testLog.Error(" _HexToPubkey: invalid length", len(retBytes))
+		panic(err)
+	}
+	copy(ret[:], retBytes)
 	return
 }
 
 // _HexToSignature converts a hexadecimal string to a BLS Signature
-func _HexToSignature(s string) (ret types.Signature) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToSignature(s string) (ret phase0.BLSSignature) {
+	retBytes, err := hexutil.Decode(s)
 	if err != nil {
 		testLog.Error(err, " _HexToSignature: ", s)
 		panic(err)
 	}
+	if len(retBytes) != len(ret) {
+		testLog.Error(" _HexToSignature: invalid length", len(retBytes))
+		panic(err)
+	}
+	copy(ret[:], retBytes)
 	return
 }

--- a/server/relay_entry_test.go
+++ b/server/relay_entry_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flashbots/go-boost-utils/types"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseRelaysURLs(t *testing.T) {
 	// Used to fake a relay's public key.
-	publicKey := types.PublicKey{0x01}
+	publicKey := phase0.BLSPubKey{0x01}
 
 	testCases := []struct {
 		name     string
@@ -65,7 +65,7 @@ func TestParseRelaysURLs(t *testing.T) {
 		{
 			name:        "Relay URL with invalid public key",
 			relayURL:    "http://0x123456@foo.com",
-			expectedErr: types.ErrLength,
+			expectedErr: ErrInvalidLengthPubkey,
 		},
 		{
 			name:        "Relay URL with point-at-infinity public key",

--- a/server/types.go
+++ b/server/types.go
@@ -5,61 +5,37 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/attestantio/go-builder-client/api/capella"
-	"github.com/attestantio/go-builder-client/spec"
-	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/flashbots/go-boost-utils/types"
+	builderApiBellatrix "github.com/attestantio/go-builder-client/api/bellatrix"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/flashbots/go-boost-utils/ssz"
 )
 
 var errNoResponse = errors.New("no response")
 
 // wrapper for backwards compatible capella types
 
-type GetHeaderResponse struct {
-	Bellatrix *types.GetHeaderResponse
-	Capella   *spec.VersionedSignedBuilderBid
-}
+type GetHeaderResponse builderSpec.VersionedSignedBuilderBid
 
 func (r *GetHeaderResponse) UnmarshalJSON(data []byte) error {
-	var err error
-
-	var capella spec.VersionedSignedBuilderBid
-	err = json.Unmarshal(data, &capella)
-	if err == nil && capella.Capella != nil {
-		r.Capella = &capella
-		return nil
-	}
-
-	var bellatrix types.GetHeaderResponse
-	err = json.Unmarshal(data, &bellatrix)
-	if err != nil {
-		return err
-	}
-
-	r.Bellatrix = &bellatrix
-
-	return nil
+	return json.Unmarshal(data, (*builderSpec.VersionedSignedBuilderBid)(r))
 }
 
 func (r *GetHeaderResponse) MarshalJSON() ([]byte, error) {
-	if r.Capella != nil {
-		return json.Marshal(r.Capella)
-	}
-
-	if r.Bellatrix != nil {
-		return json.Marshal(r.Bellatrix)
-	}
-
-	return nil, errNoResponse
+	return json.Marshal(&builderSpec.VersionedSignedBuilderBid{
+		Version:   r.Version,
+		Bellatrix: r.Bellatrix,
+		Capella:   r.Capella,
+	})
 }
 
 func (r *GetHeaderResponse) IsInvalid() bool {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data == nil || r.Bellatrix.Data.Message == nil || r.Bellatrix.Data.Message.Header == nil || r.Bellatrix.Data.Message.Header.BlockHash == nilHash
+		return r.Bellatrix == nil || r.Bellatrix.Message == nil || r.Bellatrix.Message.Header == nil || r.Bellatrix.Message.Header.BlockHash == nilHash
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella == nil || r.Capella.Capella.Message == nil || r.Capella.Capella.Message.Header == nil || r.Capella.Capella.Message.Header.BlockHash == phase0.Hash32(nilHash)
+		return r.Capella == nil || r.Capella.Message == nil || r.Capella.Message.Header == nil || r.Capella.Message.Header.BlockHash == nilHash
 	}
 
 	return true
@@ -67,11 +43,11 @@ func (r *GetHeaderResponse) IsInvalid() bool {
 
 func (r *GetHeaderResponse) BlockHash() string {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message.Header.BlockHash.String()
+		return r.Bellatrix.Message.Header.BlockHash.String()
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message.Header.BlockHash.String()
+		return r.Capella.Message.Header.BlockHash.String()
 	}
 
 	return ""
@@ -79,11 +55,11 @@ func (r *GetHeaderResponse) BlockHash() string {
 
 func (r *GetHeaderResponse) Value() *big.Int {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message.Value.BigInt()
+		return r.Bellatrix.Message.Value.ToBig()
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message.Value.ToBig()
+		return r.Capella.Message.Value.ToBig()
 	}
 
 	return nil
@@ -91,11 +67,11 @@ func (r *GetHeaderResponse) Value() *big.Int {
 
 func (r *GetHeaderResponse) BlockNumber() uint64 {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message.Header.BlockNumber
+		return r.Bellatrix.Message.Header.BlockNumber
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message.Header.BlockNumber
+		return r.Capella.Message.Header.BlockNumber
 	}
 
 	return 0
@@ -103,11 +79,11 @@ func (r *GetHeaderResponse) BlockNumber() uint64 {
 
 func (r *GetHeaderResponse) TransactionsRoot() string {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message.Header.TransactionsRoot.String()
+		return r.Bellatrix.Message.Header.TransactionsRoot.String()
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message.Header.TransactionsRoot.String()
+		return r.Capella.Message.Header.TransactionsRoot.String()
 	}
 
 	return ""
@@ -115,11 +91,11 @@ func (r *GetHeaderResponse) TransactionsRoot() string {
 
 func (r *GetHeaderResponse) Pubkey() string {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message.Pubkey.String()
+		return r.Bellatrix.Message.Pubkey.String()
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message.Pubkey.String()
+		return r.Capella.Message.Pubkey.String()
 	}
 
 	return ""
@@ -127,23 +103,23 @@ func (r *GetHeaderResponse) Pubkey() string {
 
 func (r *GetHeaderResponse) Signature() []byte {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Signature[:]
+		return r.Bellatrix.Signature[:]
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Signature[:]
+		return r.Capella.Signature[:]
 	}
 
 	return nil
 }
 
-func (r *GetHeaderResponse) Message() types.HashTreeRoot {
+func (r *GetHeaderResponse) Message() ssz.ObjWithHashTreeRoot {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message
+		return r.Bellatrix.Message
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message
+		return r.Capella.Message
 	}
 
 	return nil
@@ -151,11 +127,11 @@ func (r *GetHeaderResponse) Message() types.HashTreeRoot {
 
 func (r *GetHeaderResponse) ParentHash() string {
 	if r.Bellatrix != nil {
-		return r.Bellatrix.Data.Message.Header.ParentHash.String()
+		return r.Bellatrix.Message.Header.ParentHash.String()
 	}
 
 	if r.Capella != nil {
-		return r.Capella.Capella.Message.Header.ParentHash.String()
+		return r.Capella.Message.Header.ParentHash.String()
 	}
 
 	return ""
@@ -167,35 +143,34 @@ func (r *GetHeaderResponse) IsEmpty() bool {
 
 func (r *GetHeaderResponse) BuilderBid() *SignedBuilderBid {
 	if r.Bellatrix != nil {
-		return &SignedBuilderBid{Bellatrix: r.Bellatrix.Data}
+		return &SignedBuilderBid{Bellatrix: r.Bellatrix}
 	}
 	if r.Capella != nil {
-		return &SignedBuilderBid{Capella: r.Capella.Capella}
+		return &SignedBuilderBid{Capella: r.Capella}
 	}
 	return nil
 }
 
 type SignedBuilderBid struct {
-	Bellatrix *types.SignedBuilderBid
-	Capella   *capella.SignedBuilderBid
+	Bellatrix *builderApiBellatrix.SignedBuilderBid
+	Capella   *builderApiCapella.SignedBuilderBid
 }
 
 func (r *SignedBuilderBid) UnmarshalJSON(data []byte) error {
-	var err error
-	var bellatrix types.SignedBuilderBid
+	var capella builderApiCapella.SignedBuilderBid
+	err := json.Unmarshal(data, &capella)
+	if err != nil {
+		r.Capella = &capella
+		return err
+	}
+
+	var bellatrix builderApiBellatrix.SignedBuilderBid
 	err = json.Unmarshal(data, &bellatrix)
 	if err == nil {
 		r.Bellatrix = &bellatrix
 		return nil
 	}
 
-	var capella capella.SignedBuilderBid
-	err = json.Unmarshal(data, &capella)
-	if err != nil {
-		return err
-	}
-
-	r.Capella = &capella
 	return nil
 }
 

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"testing"
 
+	builderApi "github.com/attestantio/go-builder-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/flashbots/mev-boost/config"
 	"github.com/stretchr/testify/require"
@@ -105,7 +107,10 @@ func TestCapellaComputeBlockHash(t *testing.T) {
 	payload := new(capella.ExecutionPayload)
 	require.NoError(t, DecodeJSON(jsonFile, payload))
 
-	hash, err := ComputeBlockHash(payload)
+	hash, err := ComputeBlockHash(&builderApi.VersionedExecutionPayload{
+		Version: spec.DataVersionCapella,
+		Capella: payload,
+	})
 	require.NoError(t, err)
 	require.Equal(t, "0x08751ea2076d3ecc606231495a90ba91a66a9b8fb1a2b76c333f1957a1c667c3", hash.String())
 }

--- a/testdata/kiln-signed-blinded-beacon-block-899730.json
+++ b/testdata/kiln-signed-blinded-beacon-block-899730.json
@@ -12,6 +12,10 @@
                 "block_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
             },
             "graffiti": "0x22707279736d2d6b387322000000000000000000000000000000000000000000",
+            "proposer_slashings": [],
+            "attester_slashings": [],
+            "deposits": [],
+            "voluntary_exits": [],
             "attestations": [
                 {
                     "aggregation_bits": "0xafff7ffdfff6eeffbdfbeffdfdf77fff01",
@@ -690,6 +694,7 @@
                 "prev_randao": "0xcd4770c9aaffa84d5d4d2c10aabdb2474eecf62b27d2789dcafc3d078deccd58",
                 "block_number": "829552",
                 "gas_limit": "30000000",
+                "gas_used": "0",
                 "timestamp": "1657804260",
                 "extra_data": "0x466c617368626f747320666c617368626c6f636b",
                 "base_fee_per_gas": "7",


### PR DESCRIPTION
## 📝 Summary

Replace go-boost-utils types with [`attestantio/go-builder-client`](https://github.com/attestantio/go-builder-client) and [`attestantio/go-eth2-client`](https://github.com/attestantio/go-eth2-client) types.

* Replace types with Attestant types.
* Uncomment out a few test cases.
* Add some missing field to the `kiln-signed-blinded-beacon-block` which were missing.
  * The go-boost-utils types wouldn't error here.
* Comment out line that sends bid and signed block to relay monitor.
  * This is only in Bellatrix right now, do we still want this? 

## ⛱ Motivation and Context

Since Capella, things are kind of a mixed bag; some types from go-boost-utils & some types from Attestant. I think it would be a good idea to consolidate to the Attestant types, which I feel are pretty high quality.

## 📚 References

A new release with this PR in go-boost-utils must be merged first:

* https://github.com/flashbots/go-boost-utils/pull/71

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
