### PR TITLE
allow skipping relay signature check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,13 @@ lint:
 	staticcheck ./...
 	golangci-lint run
 
+.PHONY: fmt
+fmt:
+	gofmt -s -w .
+	gofumpt -extra -w .
+	gci write .
+	go mod tidy
+
 .PHONY: test-coverage
 test-coverage:
 	CGO_ENABLED=0 go test -v -covermode=atomic -coverprofile=coverage.out ./...

--- a/config/vars.go
+++ b/config/vars.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+
 	"github.com/flashbots/go-utils/cli"
 )
 
@@ -28,4 +30,6 @@ var (
 	ServerIdleTimeoutMs = cli.GetEnvInt("MEV_BOOST_SERVER_IDLE_TIMEOUT_MS", 0)
 
 	ServerMaxHeaderBytes = cli.GetEnvInt("MAX_HEADER_BYTES", 4000) // max header byte size for requests for dos prevention
+
+	SkipRelaySignatureCheck = os.Getenv("SKIP_RELAY_SIGNATURE_CHECK") == "1"
 )

--- a/server/service.go
+++ b/server/service.go
@@ -364,14 +364,16 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			}
 
 			// Verify the relay signature in the relay response
-			ok, err := types.VerifySignature(responsePayload.Message(), m.builderSigningDomain, relay.PublicKey[:], responsePayload.Signature())
-			if err != nil {
-				log.WithError(err).Error("error verifying relay signature")
-				return
-			}
-			if !ok {
-				log.Error("failed to verify relay signature")
-				return
+			if !config.SkipRelaySignatureCheck {
+				ok, err := types.VerifySignature(responsePayload.Message(), m.builderSigningDomain, relay.PublicKey[:], responsePayload.Signature())
+				if err != nil {
+					log.WithError(err).Error("error verifying relay signature")
+					return
+				}
+				if !ok {
+					log.Error("failed to verify relay signature")
+					return
+				}
 			}
 
 			// Verify response coherence with proposer's input data


### PR DESCRIPTION
## 📝 Summary

Allow skipping of relay signature check with environment variable `SKIP_RELAY_SIGNATURE_CHECK=1`.

This allows automated test deployments without needing to configure a specific relay private key.

See also https://github.com/flashbots/mev-boost/issues/499


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
