### PR TITLE
log ms into slot when getHeader/getPayload requests start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ lint:
 	staticcheck ./...
 	golangci-lint run
 
+.PHONY: lt
+lt: lint test
+
 .PHONY: fmt
 fmt:
 	gofmt -s -w .

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -5,25 +5,26 @@ import (
 	"testing"
 
 	"github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/mev-boost/common"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFloatEthTo256Wei(t *testing.T) {
 	// test with small input
 	i := 0.000000000000012345
-	weiU256, err := floatEthTo256Wei(i)
+	weiU256, err := common.FloatEthTo256Wei(i)
 	require.NoError(t, err)
 	require.Equal(t, types.IntToU256(12345), *weiU256)
 
 	// test with zero
 	i = 0
-	weiU256, err = floatEthTo256Wei(i)
+	weiU256, err = common.FloatEthTo256Wei(i)
 	require.NoError(t, err)
 	require.Equal(t, types.IntToU256(0), *weiU256)
 
 	// test with large input
 	i = 987654.3
-	weiU256, err = floatEthTo256Wei(i)
+	weiU256, err = common.FloatEthTo256Wei(i)
 	require.NoError(t, err)
 
 	r := big.NewInt(9876543)

--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"math/big"
+	"os"
+	"strconv"
+
+	"github.com/flashbots/go-boost-utils/types"
+)
+
+const (
+	GenesisTimeMainnet = 1606824023
+	SlotTimeSecMainnet = 12
+)
+
+func GetEnv(key, defaultValue string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return defaultValue
+}
+
+func GetEnvInt(key string, defaultValue int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		val, err := strconv.Atoi(value)
+		if err == nil {
+			return val
+		}
+	}
+	return defaultValue
+}
+
+func GetEnvFloat64(key string, defaultValue float64) float64 {
+	if value, ok := os.LookupEnv(key); ok {
+		val, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			return val
+		}
+	}
+	return defaultValue
+}
+
+// FloatEthTo256Wei converts a float (precision 10) denominated in eth to a U256Str denominated in wei
+func FloatEthTo256Wei(val float64) (*types.U256Str, error) {
+	weiU256 := new(types.U256Str)
+	ethFloat := new(big.Float)
+	weiFloat := new(big.Float)
+	weiFloatLessPrecise := new(big.Float)
+	weiInt := new(big.Int)
+
+	ethFloat.SetFloat64(val)
+	weiFloat.Mul(ethFloat, big.NewFloat(1e18))
+	weiFloatLessPrecise.SetString(weiFloat.String())
+	weiFloatLessPrecise.Int(weiInt)
+
+	err := weiU256.FromBig(weiInt)
+	return weiU256, err
+}

--- a/config/vars.go
+++ b/config/vars.go
@@ -3,7 +3,7 @@ package config
 import (
 	"os"
 
-	"github.com/flashbots/go-utils/cli"
+	"github.com/flashbots/mev-boost/common"
 )
 
 // Set during build
@@ -18,18 +18,23 @@ const (
 // Other settings
 var (
 	// ServerReadTimeoutMs sets the maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout.
-	ServerReadTimeoutMs = cli.GetEnvInt("MEV_BOOST_SERVER_READ_TIMEOUT_MS", 1000)
+	ServerReadTimeoutMs = common.GetEnvInt("MEV_BOOST_SERVER_READ_TIMEOUT_MS", 1000)
 
 	// ServerReadHeaderTimeoutMs sets the amount of time allowed to read request headers.
-	ServerReadHeaderTimeoutMs = cli.GetEnvInt("MEV_BOOST_SERVER_READ_HEADER_TIMEOUT_MS", 1000)
+	ServerReadHeaderTimeoutMs = common.GetEnvInt("MEV_BOOST_SERVER_READ_HEADER_TIMEOUT_MS", 1000)
 
 	// ServerWriteTimeoutMs sets the maximum duration before timing out writes of the response.
-	ServerWriteTimeoutMs = cli.GetEnvInt("MEV_BOOST_SERVER_WRITE_TIMEOUT_MS", 0)
+	ServerWriteTimeoutMs = common.GetEnvInt("MEV_BOOST_SERVER_WRITE_TIMEOUT_MS", 0)
 
 	// ServerIdleTimeoutMs sets the maximum amount of time to wait for the next request when keep-alives are enabled.
-	ServerIdleTimeoutMs = cli.GetEnvInt("MEV_BOOST_SERVER_IDLE_TIMEOUT_MS", 0)
+	ServerIdleTimeoutMs = common.GetEnvInt("MEV_BOOST_SERVER_IDLE_TIMEOUT_MS", 0)
 
-	ServerMaxHeaderBytes = cli.GetEnvInt("MAX_HEADER_BYTES", 4000) // max header byte size for requests for dos prevention
+	// ServerMaxHeaderBytes defines the max header byte size for requests (for dos prevention)
+	ServerMaxHeaderBytes = common.GetEnvInt("MAX_HEADER_BYTES", 4000)
 
+	// SkipRelaySignatureCheck can be used to disable relay signature check
 	SkipRelaySignatureCheck = os.Getenv("SKIP_RELAY_SIGNATURE_CHECK") == "1"
+
+	GenesisTime = int64(common.GetEnvInt("GENESIS_TIMESTAMP", common.GenesisTimeMainnet))
+	SlotTimeSec = int64(common.GetEnvInt("SLOT_SEC", common.SlotTimeSecMainnet))
 )

--- a/server/service.go
+++ b/server/service.go
@@ -319,6 +319,17 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	// If genesisTime and slotTimeSec are set, log how late into the slot the request started
+	if config.GenesisTime > 0 && config.SlotTimeSec > 0 {
+		slotStartTimestamp := config.GenesisTime + (int64(_slot) * config.SlotTimeSec)
+		msIntoSlot := time.Now().UTC().UnixMilli() - (slotStartTimestamp * 1000)
+		log = log.WithField("msIntoSlot", msIntoSlot)
+		log.WithFields(logrus.Fields{
+			"genesisTime": config.GenesisTime,
+			"slotTimeSec": config.SlotTimeSec,
+		}).Infof("getHeader request start at %d milliseconds into slot %d", msIntoSlot, _slot)
+	}
+
 	result := bidResp{}                           // the final response, containing the highest bid (if any)
 	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a specific blockHash
 

--- a/server/service.go
+++ b/server/service.go
@@ -708,7 +708,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 
 func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request) {
 	log := m.log.WithField("method", "getPayload")
-	log.Debug("getPayload")
+	log.Info("getPayload request starts")
 
 	// Read the body first, so we can log it later on error
 	body, err := io.ReadAll(req.Body)

--- a/server/service.go
+++ b/server/service.go
@@ -295,6 +295,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	slot := vars["slot"]
 	parentHashHex := vars["parent_hash"]
 	pubkey := vars["pubkey"]
+
 	log := m.log.WithFields(logrus.Fields{
 		"method":     "getHeader",
 		"slot":       slot,
@@ -319,16 +320,14 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	// If genesisTime and slotTimeSec are set, log how late into the slot the request started
-	if config.GenesisTime > 0 && config.SlotTimeSec > 0 {
-		slotStartTimestamp := config.GenesisTime + (int64(_slot) * config.SlotTimeSec)
-		msIntoSlot := time.Now().UTC().UnixMilli() - (slotStartTimestamp * 1000)
-		log = log.WithField("msIntoSlot", msIntoSlot)
-		log.WithFields(logrus.Fields{
-			"genesisTime": config.GenesisTime,
-			"slotTimeSec": config.SlotTimeSec,
-		}).Infof("getHeader request start at %d milliseconds into slot %d", msIntoSlot, _slot)
-	}
+	// Log how late into the slot the request starts
+	slotStartTimestamp := config.GenesisTime + (int64(_slot) * config.SlotTimeSec)
+	msIntoSlot := time.Now().UTC().UnixMilli() - (slotStartTimestamp * 1000)
+	log.WithFields(logrus.Fields{
+		"genesisTime": config.GenesisTime,
+		"slotTimeSec": config.SlotTimeSec,
+		"msIntoSlot":  msIntoSlot,
+	}).Infof("getHeader request start - %d milliseconds into slot %d", msIntoSlot, _slot)
 
 	result := bidResp{}                           // the final response, containing the highest bid (if any)
 	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a specific blockHash
@@ -589,23 +588,23 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 		return
 	}
 
+	// Prepare logger
 	log = log.WithFields(logrus.Fields{
 		"slot":       payload.Message.Slot,
 		"blockHash":  payload.Message.Body.ExecutionPayloadHeader.BlockHash.String(),
 		"parentHash": payload.Message.Body.ExecutionPayloadHeader.ParentHash.String(),
 	})
 
-	// If genesisTime and slotTimeSec are set, log how much into the slot the request started
-	if config.GenesisTime > 0 && config.SlotTimeSec > 0 {
-		slotStartTimestamp := config.GenesisTime + (int64(payload.Message.Slot) * config.SlotTimeSec)
-		msIntoSlot := time.Now().UTC().UnixMilli() - (slotStartTimestamp * 1000)
-		log = log.WithField("msIntoSlot", msIntoSlot)
-		log.WithFields(logrus.Fields{
-			"genesisTime": config.GenesisTime,
-			"slotTimeSec": config.SlotTimeSec,
-		}).Infof("Processing Capella submitBlindedBlock - request starts %d milliseconds into slot %d", msIntoSlot, payload.Message.Slot)
-	}
+	// Log how late into the slot the request starts
+	slotStartTimestamp := config.GenesisTime + (int64(payload.Message.Slot) * config.SlotTimeSec)
+	msIntoSlot := time.Now().UTC().UnixMilli() - (slotStartTimestamp * 1000)
+	log.WithFields(logrus.Fields{
+		"genesisTime": config.GenesisTime,
+		"slotTimeSec": config.SlotTimeSec,
+		"msIntoSlot":  msIntoSlot,
+	}).Infof("submitBlindedBlock request start - %d milliseconds into slot %d", msIntoSlot, payload.Message.Slot)
 
+	// Get the bid!
 	bidKey := bidRespKey{slot: uint64(payload.Message.Slot), blockHash: payload.Message.Body.ExecutionPayloadHeader.BlockHash.String()}
 	m.bidsLock.Lock()
 	originalBid := m.bids[bidKey]
@@ -708,7 +707,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 
 func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request) {
 	log := m.log.WithField("method", "getPayload")
-	log.Info("getPayload request starts")
+	log.Debug("getPayload request starts")
 
 	// Read the body first, so we can log it later on error
 	body, err := io.ReadAll(req.Body)


### PR DESCRIPTION
## 📝 Summary

Log how late into the slot the `getHeader` and `getPayload` requests start. 

This is particularly useful if proposers submit logs to debug the "too late request" response from the relay (i.e. when the relay received the request >4 sec into the slot). To be specific, this can tell whether the request started too late in the first place, or if it's the network between the proposer and relay

Moved the `GetEnv*` methods to a new `common` package, which also holds the default (mainnet) genesis time and slot time (12 sec). This removes the import of `go-utils/cli` across the package too!

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
