### PR TITLE
docs: main -> develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Relays aggregate blocks from **multiple** builders in order to select the block 
 A MEV-Boost security assessment was conducted on 2022-06-20 by [lotusbumi](https://github.com/lotusbumi). Additional information can be found in the [Security](#security) section of this repository.
 
 
-![MEV-Boost service integration overview](https://raw.githubusercontent.com/flashbots/mev-boost/main/docs/mev-boost-integration-overview.png)
+![MEV-Boost service integration overview](https://raw.githubusercontent.com/flashbots/mev-boost/54567443e718b09f8034d677723476b679782fb7/docs/mev-boost-integration-overview.png)
 
 ## Who can run MEV-Boost?
 
@@ -104,7 +104,7 @@ Ensure you are downloading the most updated MEV-Boost release. Releases are avai
 clone the repository and build it:
 
 ```bash
-# By default, the main branch includes ongoing merged PRs a future release.
+# By default, the develop branch includes ongoing merged PRs a future release.
 git clone https://github.com/flashbots/mev-boost.git
 cd mev-boost
 
@@ -225,7 +225,7 @@ Run MEV-Boost pointed at a Zhejiang relay:
 
 ## mev-boost cli arguments
 
-These are the CLI arguments for the main branch. For arguments available in a specific release, check the [release page](https://github.com/flashbots/mev-boost/releases).
+These are the CLI arguments for the develop branch. For arguments available in a specific release, check the [release page](https://github.com/flashbots/mev-boost/releases).
 
 ```
 $ ./mev-boost -help

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,10 +81,10 @@ To create a new version (with tag), follow all these steps! They are necessary t
 * Update the `stable` branch:
   * `git checkout stable`
   * `git merge tags/v2.3.1 --ff-only`
-  * `git checkout main`
+  * `git checkout develop`
   * `git merge tags/v2.3.1 --ff-only`
-* Update `Version` in `config/vars.go` to next patch with `dev` suffix (eg. `v2.3.2-dev`), commit to main and push to Github
-* Now push the main and stable branch, as well as the tag to Github: `git push origin main stable --tags`
+* Update `Version` in `config/vars.go` to next patch with `dev` suffix (eg. `v2.3.2-dev`), commit to develop and push to Github
+* Now push the develop and stable branches, as well as the tag to Github: `git push origin develop stable --tags`
 
 Now check the Github CI actions for release activity: https://github.com/flashbots/mev-boost/actions
 * CI builds and pushes the Docker image, and prepares a new draft release in https://github.com/flashbots/mev-boost/releases


### PR DESCRIPTION
## 📝 Summary

Update docs to use `develop` instead of `main` branch.

branch `main` has been replaced with `develop` as of 2023-05-16: https://github.com/flashbots/mev-boost/issues/357

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
