### PR TITLE
Upgrade go-boost-utils

### DIFF
--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -8,8 +8,13 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/attestantio/go-builder-client/api"
+	"github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/api/v1/capella"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
-	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/go-boost-utils/ssz"
 	"github.com/flashbots/mev-boost/server"
 	"github.com/sirupsen/logrus"
 )
@@ -25,7 +30,7 @@ func doGenerateValidator(filePath string, gasLimit uint64, feeRecipient string) 
 	log.WithField("file", filePath).Info("Saved validator data")
 }
 
-func doRegisterValidator(v validatorPrivateData, boostEndpoint string, builderSigningDomain boostTypes.Domain) {
+func doRegisterValidator(v validatorPrivateData, boostEndpoint string, builderSigningDomain phase0.Domain) {
 	message, err := v.PrepareRegistrationMessage(builderSigningDomain)
 	if err != nil {
 		log.WithError(err).Fatal("Could not prepare registration message")
@@ -39,7 +44,7 @@ func doRegisterValidator(v validatorPrivateData, boostEndpoint string, builderSi
 	log.WithError(err).Info("Registered validator")
 }
 
-func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, builderSigningDomain boostTypes.Domain) boostTypes.GetHeaderResponse {
+func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, builderSigningDomain phase0.Domain) spec.VersionedSignedBuilderBid {
 	// Mergemock needs to call forkchoice update before getHeader, for non-mergemock beacon node this is a no-op
 	err := beaconNode.onGetHeader()
 	if err != nil {
@@ -66,17 +71,17 @@ func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon
 
 	uri := fmt.Sprintf("%s/eth/v1/builder/header/%d/%s/%s", boostEndpoint, currentBlock.Slot+1, currentBlockHash, v.Pk.String())
 
-	var getHeaderResp boostTypes.GetHeaderResponse
+	var getHeaderResp spec.VersionedSignedBuilderBid
 	if _, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, uri, "test-cli", nil, nil, &getHeaderResp); err != nil {
 		log.WithError(err).WithField("currentBlockHash", currentBlockHash).Fatal("Could not get header")
 	}
 
-	if getHeaderResp.Data.Message == nil {
+	if getHeaderResp.Capella.Message == nil {
 		log.Fatal("Did not receive correct header")
 	}
-	log.WithField("header", *getHeaderResp.Data.Message).Info("Got header from boost")
+	log.WithField("header", *getHeaderResp.Capella.Message).Info("Got header from boost")
 
-	ok, err := boostTypes.VerifySignature(getHeaderResp.Data.Message, builderSigningDomain, getHeaderResp.Data.Message.Pubkey[:], getHeaderResp.Data.Signature[:])
+	ok, err := ssz.VerifySignature(getHeaderResp.Capella.Message, builderSigningDomain, getHeaderResp.Capella.Message.Pubkey[:], getHeaderResp.Capella.Signature[:])
 	if err != nil {
 		log.WithError(err).Fatal("Could not verify builder bid signature")
 	}
@@ -87,25 +92,25 @@ func doGetHeader(v validatorPrivateData, boostEndpoint string, beaconNode Beacon
 	return getHeaderResp
 }
 
-func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, builderSigningDomain, proposerSigningDomain boostTypes.Domain) {
+func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beacon, engineEndpoint string, builderSigningDomain, proposerSigningDomain phase0.Domain) {
 	header := doGetHeader(v, boostEndpoint, beaconNode, engineEndpoint, builderSigningDomain)
 
-	blindedBeaconBlock := boostTypes.BlindedBeaconBlock{
+	blindedBeaconBlock := capella.BlindedBeaconBlock{
 		Slot:          0,
 		ProposerIndex: 0,
-		ParentRoot:    boostTypes.Root{},
-		StateRoot:     boostTypes.Root{},
-		Body: &boostTypes.BlindedBeaconBlockBody{
-			RandaoReveal:           boostTypes.Signature{},
-			Eth1Data:               &boostTypes.Eth1Data{},
-			Graffiti:               boostTypes.Hash{},
-			ProposerSlashings:      []*boostTypes.ProposerSlashing{},
-			AttesterSlashings:      []*boostTypes.AttesterSlashing{},
-			Attestations:           []*boostTypes.Attestation{},
-			Deposits:               []*boostTypes.Deposit{},
-			VoluntaryExits:         []*boostTypes.SignedVoluntaryExit{},
-			SyncAggregate:          &boostTypes.SyncAggregate{},
-			ExecutionPayloadHeader: header.Data.Message.Header,
+		ParentRoot:    phase0.Root{},
+		StateRoot:     phase0.Root{},
+		Body: &capella.BlindedBeaconBlockBody{
+			RANDAOReveal:           phase0.BLSSignature{},
+			ETH1Data:               &phase0.ETH1Data{},
+			Graffiti:               phase0.Hash32{},
+			ProposerSlashings:      []*phase0.ProposerSlashing{},
+			AttesterSlashings:      []*phase0.AttesterSlashing{},
+			Attestations:           []*phase0.Attestation{},
+			Deposits:               []*phase0.Deposit{},
+			VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
+			SyncAggregate:          &altair.SyncAggregate{},
+			ExecutionPayloadHeader: header.Capella.Message.Header,
 		},
 	}
 
@@ -114,19 +119,19 @@ func doGetPayload(v validatorPrivateData, boostEndpoint string, beaconNode Beaco
 		log.WithError(err).Fatal("could not sign blinded beacon block")
 	}
 
-	payload := boostTypes.SignedBlindedBeaconBlock{
+	payload := capella.SignedBlindedBeaconBlock{
 		Message:   &blindedBeaconBlock,
 		Signature: signature,
 	}
-	var respPayload boostTypes.GetPayloadResponse
+	var respPayload api.VersionedExecutionPayload
 	if _, err := server.SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodPost, boostEndpoint+"/eth/v1/builder/blinded_blocks", "test-cli", nil, payload, &respPayload); err != nil {
 		log.WithError(err).Fatal("could not get payload")
 	}
 
-	if respPayload.Data == nil {
+	if respPayload.IsEmpty() {
 		log.Fatal("Did not receive correct payload")
 	}
-	log.WithField("payload", *respPayload.Data).Info("got payload from mev-boost")
+	log.WithField("payload", respPayload).Info("got payload from mev-boost")
 }
 
 func main() {
@@ -210,7 +215,7 @@ func main() {
 		if err := registerCommand.Parse(os.Args[2:]); err != nil {
 			log.Fatal(err)
 		}
-		builderSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
+		builderSigningDomain, err := server.ComputeDomain(ssz.DomainTypeAppBuilder, genesisForkVersionStr, phase0.Root{}.String())
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")
 		}
@@ -219,7 +224,7 @@ func main() {
 		if err := getHeaderCommand.Parse(os.Args[2:]); err != nil {
 			log.Fatal(err)
 		}
-		builderSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
+		builderSigningDomain, err := server.ComputeDomain(ssz.DomainTypeAppBuilder, genesisForkVersionStr, phase0.Root{}.String())
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")
 		}
@@ -228,11 +233,11 @@ func main() {
 		if err := getPayloadCommand.Parse(os.Args[2:]); err != nil {
 			log.Fatal(err)
 		}
-		builderSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeAppBuilder, genesisForkVersionStr, boostTypes.Root{}.String())
+		builderSigningDomain, err := server.ComputeDomain(ssz.DomainTypeAppBuilder, genesisForkVersionStr, phase0.Root{}.String())
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")
 		}
-		proposerSigningDomain, err := server.ComputeDomain(boostTypes.DomainTypeBeaconProposer, bellatrixForkVersionStr, genesisValidatorsRootStr)
+		proposerSigningDomain, err := server.ComputeDomain(ssz.DomainTypeBeaconProposer, bellatrixForkVersionStr, genesisValidatorsRootStr)
 		if err != nil {
 			log.WithError(err).Fatal("computing signing domain failed")
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.12.0
-	github.com/flashbots/go-boost-utils v1.6.0
+	github.com/flashbots/go-boost-utils v1.7.1-0.20230625230411-8c44018f4777
 	github.com/flashbots/go-utils v0.4.8
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/ferranbt/fastssz v0.1.3 h1:ZI+z3JH05h4kgmFXdHuR1aWYsgrg7o+Fw7/NCzM16Mo=
 github.com/ferranbt/fastssz v0.1.3/go.mod h1:0Y9TEd/9XuFlh7mskMPfXiI2Dkw4Ddg9EyXt1W7MRvE=
-github.com/flashbots/go-boost-utils v1.6.0 h1:XIcPDG6q0Tesh3kcCXyv61ncD/WVYOMCO2OVzPznvMA=
-github.com/flashbots/go-boost-utils v1.6.0/go.mod h1:fL9Jc738zFENkbn5HNnVzIfuRcvCO1djlT/ylyT34Zw=
+github.com/flashbots/go-boost-utils v1.7.1-0.20230625230411-8c44018f4777 h1:mnwpdE/JW74My5u3Ag1IMX8PgCa7aZwgFNPB20HN/DM=
+github.com/flashbots/go-boost-utils v1.7.1-0.20230625230411-8c44018f4777/go.mod h1:Rckma9iiHGuw4PQj/BFV1ddN13lUib4sTfF3QUY40Z8=
 github.com/flashbots/go-utils v0.4.8 h1:WDJXryrqShGq4HFe+p1kGjObXSqzT7Sy/+9YvFpr5tM=
 github.com/flashbots/go-utils v0.4.8/go.mod h1:dBmSv4Cpqij4xKP50bdisAvFIo4/EgsY97BMpVjPzr0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/server/mock_types.go
+++ b/server/mock_types.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/go-boost-utils/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,8 +21,8 @@ func _HexToBytes(hex string) []byte {
 }
 
 // _HexToHash converts a hexadecimal string to an Ethereum hash
-func _HexToHash(s string) (ret types.Hash) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToHash(s string) (ret phase0.Hash32) {
+	ret, err := utils.HexToHash(s)
 	if err != nil {
 		testLog.Error(err, " _HexToHash: ", s)
 		panic(err)
@@ -29,8 +31,8 @@ func _HexToHash(s string) (ret types.Hash) {
 }
 
 // _HexToAddress converts a hexadecimal string to an Ethereum address
-func _HexToAddress(s string) (ret types.Address) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToAddress(s string) (ret bellatrix.ExecutionAddress) {
+	ret, err := utils.HexToAddress(s)
 	if err != nil {
 		testLog.Error(err, " _HexToAddress: ", s)
 		panic(err)
@@ -39,8 +41,8 @@ func _HexToAddress(s string) (ret types.Address) {
 }
 
 // _HexToPubkey converts a hexadecimal string to a BLS Public Key
-func _HexToPubkey(s string) (ret types.PublicKey) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToPubkey(s string) (ret phase0.BLSPubKey) {
+	ret, err := utils.HexToPubkey(s)
 	if err != nil {
 		testLog.Error(err, " _HexToPubkey: ", s)
 		panic(err)
@@ -49,8 +51,8 @@ func _HexToPubkey(s string) (ret types.PublicKey) {
 }
 
 // _HexToSignature converts a hexadecimal string to a BLS Signature
-func _HexToSignature(s string) (ret types.Signature) {
-	err := ret.UnmarshalText([]byte(s))
+func _HexToSignature(s string) (ret phase0.BLSSignature) {
+	ret, err := utils.HexToSignature(s)
 	if err != nil {
 		testLog.Error(err, " _HexToSignature: ", s)
 		panic(err)

--- a/server/relay_entry.go
+++ b/server/relay_entry.go
@@ -5,7 +5,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/flashbots/go-boost-utils/types"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/flashbots/go-boost-utils/utils"
 )
 
 // The point-at-infinity is 48 zero bytes.
@@ -13,7 +14,7 @@ var pointAtInfinityPubkey = [48]byte{}
 
 // RelayEntry represents a relay that mev-boost connects to.
 type RelayEntry struct {
-	PublicKey types.PublicKey
+	PublicKey phase0.BLSPubKey
 	URL       *url.URL
 }
 
@@ -46,7 +47,7 @@ func NewRelayEntry(relayURL string) (entry RelayEntry, err error) {
 	}
 
 	// Convert the username string to a public key.
-	err = entry.PublicKey.UnmarshalText([]byte(entry.URL.User.Username()))
+	entry.PublicKey, err = utils.HexToPubkey(entry.URL.User.Username())
 	if err != nil {
 		return entry, err
 	}

--- a/server/relay_entry_test.go
+++ b/server/relay_entry_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseRelaysURLs(t *testing.T) {
 	// Used to fake a relay's public key.
-	publicKey := types.PublicKey{0x01}
+	publicKey := phase0.BLSPubKey{0x01}
 
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Upgrade all the types to attestant by upgrading go-boost-utils in https://github.com/flashbots/go-boost-utils/pull/76. Tidying up types in the `common/` folder will be in a follow up PR.

## ⛱ Motivation and Context

We want to move away from go-boost-utils types entirely and move all types to attestant. This PR is part of the migration move entirely to attestant, switching the util functions to attestant types.
<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
