### PR TITLE
remove forkversion header (it's unused and not necessary)

### DIFF
--- a/config/vars.go
+++ b/config/vars.go
@@ -6,14 +6,8 @@ import (
 	"github.com/flashbots/mev-boost/common"
 )
 
-// Set during build
-const (
-	// Version is the version of the software, set at build time
-	Version = "v1.5.1-dev"
-
-	// ForkVersion is the latest supported fork version at build time
-	ForkVersion = "capella"
-)
+// Version is set at build time
+const Version = "v1.5.1-dev"
 
 // Other settings
 var (

--- a/server/service.go
+++ b/server/service.go
@@ -245,7 +245,6 @@ func (m *BoostService) handleRoot(w http.ResponseWriter, req *http.Request) {
 // It returns OK if at least one returned OK, and returns error otherwise.
 func (m *BoostService) handleStatus(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set(HeaderKeyVersion, config.Version)
-	w.Header().Set(HeaderKeyForkVersion, config.ForkVersion)
 	if !m.relayCheck || m.CheckRelays() > 0 {
 		m.respondOK(w, nilResponse)
 	} else {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/go-boost-utils/types"
-	"github.com/flashbots/mev-boost/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -192,7 +191,6 @@ func TestStatus(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		require.True(t, len(rr.Header().Get("X-MEVBoost-Version")) > 0)
-		require.Equal(t, config.ForkVersion, rr.Header().Get("X-MEVBoost-ForkVersion"))
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
@@ -205,7 +203,6 @@ func TestStatus(t *testing.T) {
 
 		require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 		require.True(t, len(rr.Header().Get("X-MEVBoost-Version")) > 0)
-		require.Equal(t, config.ForkVersion, rr.Header().Get("X-MEVBoost-ForkVersion"))
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
 }


### PR DESCRIPTION
## 📝 Summary

Minor simplification - removing ForkVersion header which isn't used


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
