### PR TITLE
logs with millisecond timestamp

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -94,15 +94,14 @@ func Main() {
 
 	// setup logging
 	log.Logger.SetOutput(os.Stdout)
-	rfc3339Milli := "2006-01-02T15:04:05.999Z07:00"
 	if *logJSON {
 		log.Logger.SetFormatter(&logrus.JSONFormatter{
-			TimestampFormat: rfc3339Milli,
+			TimestampFormat: config.RFC3339Milli,
 		})
 	} else {
 		log.Logger.SetFormatter(&logrus.TextFormatter{
 			FullTimestamp:   true,
-			TimestampFormat: rfc3339Milli,
+			TimestampFormat: config.RFC3339Milli,
 		})
 	}
 	if *logDebug {

--- a/cli/main.go
+++ b/cli/main.go
@@ -94,11 +94,15 @@ func Main() {
 
 	// setup logging
 	log.Logger.SetOutput(os.Stdout)
+	rfc3339Milli := "2006-01-02T15:04:05.999Z07:00"
 	if *logJSON {
-		log.Logger.SetFormatter(&logrus.JSONFormatter{})
+		log.Logger.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: rfc3339Milli,
+		})
 	} else {
 		log.Logger.SetFormatter(&logrus.TextFormatter{
-			FullTimestamp: true,
+			FullTimestamp:   true,
+			TimestampFormat: rfc3339Milli,
 		})
 	}
 	if *logDebug {

--- a/config/vars.go
+++ b/config/vars.go
@@ -17,6 +17,9 @@ const (
 
 // Other settings
 var (
+	// RFC3339Milli is a time format string based on time.RFC3339 but with millisecond precision
+	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+
 	// ServerReadTimeoutMs sets the maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout.
 	ServerReadTimeoutMs = common.GetEnvInt("MEV_BOOST_SERVER_READ_TIMEOUT_MS", 1000)
 


### PR DESCRIPTION
## 📝 Summary

Add milliseconds to logs time

```
# before:
2023-06-19T22:42:58+02:00

# after:
2023-06-19T22:44:32.984+02:00
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
