### PR TITLE
fix build version

### DIFF
--- a/config/vars.go
+++ b/config/vars.go
@@ -6,11 +6,10 @@ import (
 	"github.com/flashbots/mev-boost/common"
 )
 
-// Version is set at build time
-const Version = "v1.7-dev"
-
-// Other settings
 var (
+	// Version is set at build time (must be a var, not a const!)
+	Version = "v1.7-dev"
+
 	// RFC3339Milli is a time format string based on time.RFC3339 but with millisecond precision
 	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
 


### PR DESCRIPTION
## 📝 Summary

`make` wouldn't set the build version correctly because it was a `const` instead of `var`.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
