### PR TITLE
Remove unused HeaderKeyForkVersion

### DIFF
--- a/server/mock_relay.go
+++ b/server/mock_relay.go
@@ -105,7 +105,7 @@ func (m *mockRelay) newTestMiddleware(next http.Handler) http.Handler {
 	)
 }
 
-// getRouter registers all methods from the backend, apply the test middleware a,nd return the configured router
+// getRouter registers all methods from the backend, apply the test middleware and return the configured router
 func (m *mockRelay) getRouter() http.Handler {
 	// Create router.
 	r := mux.NewRouter()

--- a/server/utils.go
+++ b/server/utils.go
@@ -28,9 +28,8 @@ import (
 )
 
 const (
-	HeaderKeySlotUID     = "X-MEVBoost-SlotID"
-	HeaderKeyVersion     = "X-MEVBoost-Version"
-	HeaderKeyForkVersion = "X-MEVBoost-ForkVersion"
+	HeaderKeySlotUID = "X-MEVBoost-SlotID"
+	HeaderKeyVersion = "X-MEVBoost-Version"
 )
 
 var (


### PR DESCRIPTION
## 📝 Summary

Removes the unused constant & minor fixes a typo.

## ⛱ Motivation and Context

I was wondering how it was used but it wasn't being used. Should probably delete.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
