### PR TITLE
fix ci run for develop branch, also fixes test badge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Linting
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 #
 
 [![Goreport status](https://goreportcard.com/badge/github.com/flashbots/mev-boost)](https://goreportcard.com/report/github.com/flashbots/mev-boost)
-[![Test status](https://github.com/flashbots/mev-boost/workflows/Tests/badge.svg)](https://github.com/flashbots/mev-boost/actions?query=workflow%3A%22Tests%22)
+[![Test status](https://github.com/flashbots/mev-boost/workflows/Tests/badge.svg?branch=develop)](https://github.com/flashbots/mev-boost/actions?query=workflow%3A%22Tests%22)
 [![Docker hub](https://badgen.net/docker/size/flashbots/mev-boost?icon=docker&label=image)](https://hub.docker.com/r/flashbots/mev-boost/tags)
 
 ## What is MEV-Boost?


### PR DESCRIPTION
## 📝 Summary

- Missing change from `main` -> `develop`
- Fixes 'failing tests' branch on develop README (currently it's just referring to whatever latest CI run, after this PR will refer to latest test on develop branch)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
