### PR TITLE
Make attestantio import names consistent

### DIFF
--- a/cmd/test-cli/validator.go
+++ b/cmd/test-cli/validator.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/flashbots/go-boost-utils/bls"
@@ -52,18 +52,18 @@ func newRandomValidator(gasLimit uint64, feeRecipient string) validatorPrivateDa
 	return validatorPrivateData{bls.SecretKeyToBytes(sk), bls.PublicKeyToBytes(pk), hexutil.Uint64(gasLimit), feeRecipient}
 }
 
-func (v *validatorPrivateData) PrepareRegistrationMessage(builderSigningDomain phase0.Domain) ([]apiv1.SignedValidatorRegistration, error) {
+func (v *validatorPrivateData) PrepareRegistrationMessage(builderSigningDomain phase0.Domain) ([]builderApiV1.SignedValidatorRegistration, error) {
 	pk := phase0.BLSPubKey{}
 	if len(v.Pk) != len(pk) {
-		return []apiv1.SignedValidatorRegistration{}, errInvalidLength
+		return []builderApiV1.SignedValidatorRegistration{}, errInvalidLength
 	}
 	copy(pk[:], v.Pk)
 
 	addr, err := utils.HexToAddress(v.FeeRecipientHex)
 	if err != nil {
-		return []apiv1.SignedValidatorRegistration{}, err
+		return []builderApiV1.SignedValidatorRegistration{}, err
 	}
-	msg := apiv1.ValidatorRegistration{
+	msg := builderApiV1.ValidatorRegistration{
 		FeeRecipient: addr,
 		Timestamp:    time.Now(),
 		Pubkey:       pk,
@@ -71,10 +71,10 @@ func (v *validatorPrivateData) PrepareRegistrationMessage(builderSigningDomain p
 	}
 	signature, err := v.Sign(&msg, builderSigningDomain)
 	if err != nil {
-		return []apiv1.SignedValidatorRegistration{}, err
+		return []builderApiV1.SignedValidatorRegistration{}, err
 	}
 
-	return []apiv1.SignedValidatorRegistration{{
+	return []builderApiV1.SignedValidatorRegistration{{
 		Message:   &msg,
 		Signature: signature,
 	}}, nil

--- a/server/mock_types_test.go
+++ b/server/mock_types_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"testing"
 
-	capellaapi "github.com/attestantio/go-builder-client/api/capella"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -202,7 +202,7 @@ func TestHexToSignature(t *testing.T) {
 
 	publicKey := hexutil.Encode(bls.PublicKeyToBytes(blsPublicKey))
 
-	message := &capellaapi.BuilderBid{
+	message := &builderApiCapella.BuilderBid{
 		Header: &capella.ExecutionPayloadHeader{
 			BlockHash: _HexToHash("0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"),
 		},

--- a/server/service.go
+++ b/server/service.go
@@ -15,14 +15,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	apiv1bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
-	"github.com/attestantio/go-eth2-client/api/v1/capella"
-	"github.com/attestantio/go-eth2-client/api/v1/deneb"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	eth2ApiV1Bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
+	eth2ApiV1Capella "github.com/attestantio/go-eth2-client/api/v1/capella"
+	eth2ApiV1Deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	denebutil "github.com/attestantio/go-eth2-client/util/deneb"
+	eth2UtilDeneb "github.com/attestantio/go-eth2-client/util/deneb"
 	"github.com/flashbots/go-boost-utils/ssz"
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/go-boost-utils/utils"
@@ -54,8 +54,8 @@ type httpErrorResp struct {
 
 // AuctionTranscript is the bid and blinded block received from the relay send to the relay monitor
 type AuctionTranscript struct {
-	Bid        *spec.VersionedSignedBuilderBid          // TODO: proper json marshalling and unmashalling
-	Acceptance *apiv1bellatrix.SignedBlindedBeaconBlock `json:"acceptance"`
+	Bid        *builderSpec.VersionedSignedBuilderBid       // TODO: proper json marshalling and unmashalling
+	Acceptance *eth2ApiV1Bellatrix.SignedBlindedBeaconBlock `json:"acceptance"`
 }
 
 type slotUID struct {
@@ -216,7 +216,7 @@ func (m *BoostService) startBidCacheCleanupTask() {
 	}
 }
 
-func (m *BoostService) sendValidatorRegistrationsToRelayMonitors(payload []apiv1.SignedValidatorRegistration) {
+func (m *BoostService) sendValidatorRegistrationsToRelayMonitors(payload []builderApiV1.SignedValidatorRegistration) {
 	log := m.log.WithField("method", "sendValidatorRegistrationsToRelayMonitors").WithField("numRegistrations", len(payload))
 	for _, relayMonitor := range m.relayMonitors {
 		go func(relayMonitor *url.URL) {
@@ -268,7 +268,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 	log := m.log.WithField("method", "registerValidator")
 	log.Debug("registerValidator")
 
-	payload := []apiv1.SignedValidatorRegistration{}
+	payload := []builderApiV1.SignedValidatorRegistration{}
 	if err := DecodeJSON(req.Body, &payload); err != nil {
 		m.respondError(w, http.StatusBadRequest, err.Error())
 		return
@@ -368,7 +368,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 
 	// Prepare relay responses
 	result := bidResp{}                           // the final response, containing the highest bid (if any)
-	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a specific blockHash
+	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a builderSpecific blockHash
 
 	// Call the relays
 	var mu sync.Mutex
@@ -380,7 +380,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			path := fmt.Sprintf("/eth/v1/builder/header/%s/%s/%s", slot, parentHashHex, pubkey)
 			url := relay.GetURI(path)
 			log := log.WithField("url", url)
-			responsePayload := new(spec.VersionedSignedBuilderBid)
+			responsePayload := new(builderSpec.VersionedSignedBuilderBid)
 			code, err := SendHTTPRequest(context.Background(), m.httpClientGetHeader, http.MethodGet, url, ua, headers, nil, responsePayload)
 			if err != nil {
 				log.WithError(err).Warn("error making request to relay")
@@ -515,7 +515,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	m.respondOK(w, &result.response)
 }
 
-func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Request, log *logrus.Entry, payload *capella.SignedBlindedBeaconBlock, body []byte) {
+func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Request, log *logrus.Entry, payload *eth2ApiV1Capella.SignedBlindedBeaconBlock, body []byte) {
 	if payload.Message == nil || payload.Message.Body == nil || payload.Message.Body.ExecutionPayloadHeader == nil {
 		log.WithField("body", string(body)).Error("missing parts of the request payload from the beacon-node")
 		m.respondError(w, http.StatusBadRequest, "missing parts of the payload")
@@ -562,7 +562,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 		log.Warn("bid found but no associated relays")
 	}
 
-	// send bid and signed block to relay monitor with capella payload
+	// send bid and signed block to relay monitor with eth2ApiV1Capella payload
 	// go m.sendAuctionTranscriptToRelayMonitors(&AuctionTranscript{Bid: originalBid.response.Data, Acceptance: payload})
 
 	// Add request headers
@@ -571,7 +571,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 	// Prepare for requests
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	result := new(api.VersionedSubmitBlindedBlockResponse)
+	result := new(builderApi.VersionedSubmitBlindedBlockResponse)
 
 	// Prepare the request context, which will be cancelled after the first successful response from a relay
 	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
@@ -585,7 +585,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 			log := log.WithField("url", url)
 			log.Debug("calling getPayload")
 
-			responsePayload := new(api.VersionedSubmitBlindedBlockResponse)
+			responsePayload := new(builderApi.VersionedSubmitBlindedBlockResponse)
 			_, err := SendHTTPRequestWithRetries(requestCtx, m.httpClientGetPayload, http.MethodPost, url, ua, headers, payload, responsePayload, m.requestMaxRetries, log)
 			if err != nil {
 				if errors.Is(requestCtx.Err(), context.Canceled) {
@@ -610,7 +610,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 			}
 
 			// Ensure the response blockhash matches the response block
-			calculatedBlockHash, err := utils.ComputeBlockHash(&api.VersionedExecutionPayload{
+			calculatedBlockHash, err := utils.ComputeBlockHash(&builderApi.VersionedExecutionPayload{
 				Version: responsePayload.Version,
 				Capella: responsePayload.Capella,
 			})
@@ -652,7 +652,7 @@ func (m *BoostService) processCapellaPayload(w http.ResponseWriter, req *http.Re
 	m.respondOK(w, result)
 }
 
-func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Request, log *logrus.Entry, payload *deneb.SignedBlindedBlockContents) {
+func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Request, log *logrus.Entry, payload *eth2ApiV1Deneb.SignedBlindedBlockContents) {
 	// no need to check if fields are nil as the json unmarshalling library does the nil check for us
 	blindedBlock := payload.SignedBlindedBlock
 	blindedBlobs := payload.SignedBlindedBlobSidecars
@@ -703,7 +703,7 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 	// Prepare for requests
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	result := new(api.VersionedSubmitBlindedBlockResponse)
+	result := new(builderApi.VersionedSubmitBlindedBlockResponse)
 
 	// Prepare the request context, which will be cancelled after the first successful response from a relay
 	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
@@ -717,7 +717,7 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 			log := log.WithField("url", url)
 			log.Debug("calling getPayload")
 
-			responsePayload := new(api.VersionedSubmitBlindedBlockResponse)
+			responsePayload := new(builderApi.VersionedSubmitBlindedBlockResponse)
 			_, err := SendHTTPRequestWithRetries(requestCtx, m.httpClientGetPayload, http.MethodPost, url, ua, headers, payload, responsePayload, m.requestMaxRetries, log)
 			if err != nil {
 				if errors.Is(requestCtx.Err(), context.Canceled) {
@@ -745,7 +745,7 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 			}
 
 			// Ensure the response blockhash matches the response block
-			calculatedBlockHash, err := utils.ComputeBlockHash(&api.VersionedExecutionPayload{
+			calculatedBlockHash, err := utils.ComputeBlockHash(&builderApi.VersionedExecutionPayload{
 				Version: responsePayload.Version,
 				Deneb:   payload,
 			})
@@ -785,7 +785,7 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 					return
 				}
 
-				blobHelper := denebutil.BeaconBlockBlob{Blob: blobs.Blobs[i]}
+				blobHelper := eth2UtilDeneb.BeaconBlockBlob{Blob: blobs.Blobs[i]}
 				blobRoot, err := blobHelper.HashTreeRoot()
 				if err != nil {
 					log.WithError(err).Error("error calculating blobRoot")
@@ -843,10 +843,10 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 	}
 
 	// Decode the body now
-	payload := new(deneb.SignedBlindedBlockContents)
+	payload := new(eth2ApiV1Deneb.SignedBlindedBlockContents)
 	if err := DecodeJSON(bytes.NewReader(body), payload); err != nil {
 		log.Debug("could not decode Deneb request payload, attempting to decode body into Capella payload")
-		payload := new(capella.SignedBlindedBeaconBlock)
+		payload := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
 		if err := DecodeJSON(bytes.NewReader(body), payload); err != nil {
 			log.WithError(err).WithField("body", string(body)).Error("could not decode request payload from the beacon-node (signed blinded beacon block)")
 			m.respondError(w, http.StatusBadRequest, err.Error())

--- a/server/service.go
+++ b/server/service.go
@@ -368,7 +368,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 
 	// Prepare relay responses
 	result := bidResp{}                           // the final response, containing the highest bid (if any)
-	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a builderSpecific blockHash
+	relays := make(map[BlockHashHex][]RelayEntry) // relays that sent the bid for a specific blockHash
 
 	// Call the relays
 	var mu sync.Mutex

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -14,19 +14,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	builderDeneb "github.com/attestantio/go-builder-client/api/deneb"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	apiv1capella "github.com/attestantio/go-eth2-client/api/v1/capella"
-	apiv1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	eth2ApiV1Capella "github.com/attestantio/go-eth2-client/api/v1/capella"
+	eth2ApiV1Deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	bellatrixutil "github.com/attestantio/go-eth2-client/util/bellatrix"
+	eth2UtilBellatrix "github.com/attestantio/go-eth2-client/util/bellatrix"
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/holiman/uint256"
 	"github.com/prysmaticlabs/go-bitfield"
@@ -90,7 +90,7 @@ func (be *testBackend) request(t *testing.T, method, path string, payload any) *
 	return rr
 }
 
-func blindedBlockToExecutionPayloadCapella(signedBlindedBeaconBlock *apiv1capella.SignedBlindedBeaconBlock) *capella.ExecutionPayload {
+func blindedBlockToExecutionPayloadCapella(signedBlindedBeaconBlock *eth2ApiV1Capella.SignedBlindedBeaconBlock) *capella.ExecutionPayload {
 	header := signedBlindedBeaconBlock.Message.Body.ExecutionPayloadHeader
 	return &capella.ExecutionPayload{
 		ParentHash:    header.ParentHash,
@@ -111,7 +111,7 @@ func blindedBlockToExecutionPayloadCapella(signedBlindedBeaconBlock *apiv1capell
 	}
 }
 
-func blindedBlockContentsToBlockContentsDeneb(signedBlindedBlockContents *apiv1deneb.SignedBlindedBlockContents) *builderDeneb.ExecutionPayloadAndBlobsBundle {
+func blindedBlockContentsToBlockContentsDeneb(signedBlindedBlockContents *eth2ApiV1Deneb.SignedBlindedBlockContents) *builderApiDeneb.ExecutionPayloadAndBlobsBundle {
 	header := signedBlindedBlockContents.SignedBlindedBlock.Message.Body.ExecutionPayloadHeader
 	commitments := make([]deneb.KzgCommitment, 0)
 	proofs := make([]deneb.KzgProof, 0)
@@ -121,7 +121,7 @@ func blindedBlockContentsToBlockContentsDeneb(signedBlindedBlockContents *apiv1d
 		proofs = append(proofs, blobSidecar.Message.KzgProof)
 		blobs = append(blobs, deneb.Blob{})
 	}
-	return &builderDeneb.ExecutionPayloadAndBlobsBundle{
+	return &builderApiDeneb.ExecutionPayloadAndBlobsBundle{
 		ExecutionPayload: &deneb.ExecutionPayload{
 			ParentHash:    header.ParentHash,
 			FeeRecipient:  header.FeeRecipient,
@@ -139,7 +139,7 @@ func blindedBlockContentsToBlockContentsDeneb(signedBlindedBlockContents *apiv1d
 			Transactions:  make([]bellatrix.Transaction, 0),
 			Withdrawals:   make([]*capella.Withdrawal, 0),
 		},
-		BlobsBundle: &builderDeneb.BlobsBundle{
+		BlobsBundle: &builderApiDeneb.BlobsBundle{
 			Commitments: commitments,
 			Proofs:      proofs,
 			Blobs:       blobs,
@@ -247,8 +247,8 @@ func TestStatus(t *testing.T) {
 
 func TestRegisterValidator(t *testing.T) {
 	path := "/eth/v1/builder/validators"
-	reg := apiv1.SignedValidatorRegistration{
-		Message: &apiv1.ValidatorRegistration{
+	reg := builderApiV1.SignedValidatorRegistration{
+		Message: &builderApiV1.ValidatorRegistration{
 			FeeRecipient: _HexToAddress("0xdb65fEd33dc262Fe09D9a2Ba8F80b329BA25f941"),
 			Timestamp:    time.Unix(1234356, 0),
 			Pubkey: _HexToPubkey(
@@ -257,7 +257,7 @@ func TestRegisterValidator(t *testing.T) {
 		Signature: _HexToSignature(
 			"0x81510b571e22f89d1697545aac01c9ad0c1e7a3e778b3078bef524efae14990e58a6e960a152abd49de2e18d7fd3081c15d5c25867ccfad3d47beef6b39ac24b6b9fbf2cfa91c88f67aff750438a6841ec9e4a06a94ae41410c4f97b75ab284c"),
 	}
-	payload := []apiv1.SignedValidatorRegistration{reg}
+	payload := []builderApiV1.SignedValidatorRegistration{reg}
 
 	t.Run("Normal function", func(t *testing.T) {
 		backend := newTestBackend(t, 1, time.Second)
@@ -336,7 +336,7 @@ func TestGetHeader(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionDeneb,
+			spec.DataVersionDeneb,
 		)
 		backend.relays[0].GetHeaderResponse = resp
 		rr := backend.request(t, http.MethodGet, path, nil)
@@ -351,7 +351,7 @@ func TestGetHeader(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 		resp.Capella.Message.Header.BlockHash = nilHash
 
@@ -378,7 +378,7 @@ func TestGetHeader(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// Simulate a different public key registered to mev-boost
@@ -400,7 +400,7 @@ func TestGetHeader(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// Scramble the signature
@@ -472,7 +472,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// First relay will return signed response with value 12347.
@@ -481,7 +481,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// First relay will return signed response with value 12346.
@@ -490,7 +490,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// Run the request.
@@ -504,7 +504,7 @@ func TestGetHeaderBids(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 		// Highest value should be 12347, i.e. second relay.
-		resp := new(spec.VersionedSignedBuilderBid)
+		resp := new(builderSpec.VersionedSignedBuilderBid)
 		err := json.Unmarshal(rr.Body.Bytes(), resp)
 		require.NoError(t, err)
 		value, err := resp.Value()
@@ -521,7 +521,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xa38385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		backend.relays[1].GetHeaderResponse = backend.relays[1].MakeGetHeaderResponse(
@@ -529,7 +529,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xa18385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		backend.relays[2].GetHeaderResponse = backend.relays[2].MakeGetHeaderResponse(
@@ -537,7 +537,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xa28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// Run the request.
@@ -551,7 +551,7 @@ func TestGetHeaderBids(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 		// Highest value should be 12347, i.e. second relay.
-		resp := new(spec.VersionedSignedBuilderBid)
+		resp := new(builderSpec.VersionedSignedBuilderBid)
 
 		err := json.Unmarshal(rr.Body.Bytes(), resp)
 		require.NoError(t, err)
@@ -573,7 +573,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xa28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// Run the request.
@@ -596,7 +596,7 @@ func TestGetHeaderBids(t *testing.T) {
 			"0xa28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
 			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-			consensusspec.DataVersionCapella,
+			spec.DataVersionCapella,
 		)
 
 		// Run the request.
@@ -606,7 +606,7 @@ func TestGetHeaderBids(t *testing.T) {
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 
 		// Value should be 12345 (min bid is 12345)
-		resp := new(spec.VersionedSignedBuilderBid)
+		resp := new(builderSpec.VersionedSignedBuilderBid)
 		err := json.Unmarshal(rr.Body.Bytes(), resp)
 		require.NoError(t, err)
 		value, err := resp.Value()
@@ -619,15 +619,15 @@ func TestGetPayload(t *testing.T) {
 	path := "/eth/v1/builder/blinded_blocks"
 
 	blockHash := _HexToHash("0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46")
-	payload := &apiv1capella.SignedBlindedBeaconBlock{
+	payload := &eth2ApiV1Capella.SignedBlindedBeaconBlock{
 		Signature: _HexToSignature(
 			"0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
-		Message: &apiv1capella.BlindedBeaconBlock{
+		Message: &eth2ApiV1Capella.BlindedBeaconBlock{
 			Slot:          1,
 			ProposerIndex: 1,
 			ParentRoot:    phase0.Root{0x01},
 			StateRoot:     phase0.Root{0x02},
-			Body: &apiv1capella.BlindedBeaconBlockBody{
+			Body: &eth2ApiV1Capella.BlindedBeaconBlockBody{
 				RANDAOReveal: phase0.BLSSignature{0xa1},
 				ETH1Data: &phase0.ETH1Data{
 					BlockHash: blockHash[:],
@@ -657,7 +657,7 @@ func TestGetPayload(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 
-		resp := new(api.VersionedSubmitBlindedBlockResponse)
+		resp := new(builderApi.VersionedSubmitBlindedBlockResponse)
 		err := json.Unmarshal(rr.Body.Bytes(), resp)
 		require.NoError(t, err)
 		require.Equal(t, payload.Message.Body.ExecutionPayloadHeader.BlockHash, resp.Capella.BlockHash)
@@ -665,8 +665,8 @@ func TestGetPayload(t *testing.T) {
 
 	t.Run("Bad response from relays", func(t *testing.T) {
 		backend := newTestBackend(t, 2, time.Second)
-		resp := &api.VersionedSubmitBlindedBlockResponse{
-			Version: consensusspec.DataVersionCapella,
+		resp := &builderApi.VersionedSubmitBlindedBlockResponse{
+			Version: spec.DataVersionCapella,
 			Capella: &capella.ExecutionPayload{Withdrawals: []*capella.Withdrawal{}},
 		}
 
@@ -769,7 +769,7 @@ func TestCheckRelays(t *testing.T) {
 }
 
 func TestEmptyTxRoot(t *testing.T) {
-	transactions := bellatrixutil.ExecutionPayloadTransactions{Transactions: []bellatrix.Transaction{}}
+	transactions := eth2UtilBellatrix.ExecutionPayloadTransactions{Transactions: []bellatrix.Transaction{}}
 	txroot, _ := transactions.HashTreeRoot()
 	txRootHex := fmt.Sprintf("0x%x", txroot)
 	require.Equal(t, "0x7ffe241ea60187fdb0187bfa22de35d1f9bed7ab061d9401fd47e34a54fbede1", txRootHex)
@@ -787,12 +787,12 @@ func TestGetPayloadWithTestdata(t *testing.T) {
 			jsonFile, err := os.Open(fn)
 			require.NoError(t, err)
 			defer jsonFile.Close()
-			signedBlindedBeaconBlock := new(apiv1capella.SignedBlindedBeaconBlock)
+			signedBlindedBeaconBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
 			require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBeaconBlock))
 
 			backend := newTestBackend(t, 1, time.Second)
-			mockResp := api.VersionedSubmitBlindedBlockResponse{
-				Version: consensusspec.DataVersionCapella,
+			mockResp := builderApi.VersionedSubmitBlindedBlockResponse{
+				Version: spec.DataVersionCapella,
 				Capella: &capella.ExecutionPayload{
 					BlockHash:   signedBlindedBeaconBlock.Message.Body.ExecutionPayloadHeader.BlockHash,
 					Withdrawals: make([]*capella.Withdrawal, 0),
@@ -804,7 +804,7 @@ func TestGetPayloadWithTestdata(t *testing.T) {
 			require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 			require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 
-			resp := new(api.VersionedSubmitBlindedBlockResponse)
+			resp := new(builderApi.VersionedSubmitBlindedBlockResponse)
 			err = json.Unmarshal(rr.Body.Bytes(), resp)
 			require.NoError(t, err)
 			require.Equal(t, signedBlindedBeaconBlock.Message.Body.ExecutionPayloadHeader.BlockHash, resp.Capella.BlockHash)
@@ -817,14 +817,14 @@ func TestGetPayloadCapella(t *testing.T) {
 	jsonFile, err := os.Open("../testdata/signed-blinded-beacon-block-capella.json")
 	require.NoError(t, err)
 	defer jsonFile.Close()
-	signedBlindedBeaconBlock := new(apiv1capella.SignedBlindedBeaconBlock)
+	signedBlindedBeaconBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
 	require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBeaconBlock))
 
 	backend := newTestBackend(t, 1, time.Second)
 
 	// Prepare getPayload response
-	backend.relays[0].GetPayloadResponse = &api.VersionedSubmitBlindedBlockResponse{
-		Version: consensusspec.DataVersionCapella,
+	backend.relays[0].GetPayloadResponse = &builderApi.VersionedSubmitBlindedBlockResponse{
+		Version: spec.DataVersionCapella,
 		Capella: blindedBlockToExecutionPayloadCapella(signedBlindedBeaconBlock),
 	}
 
@@ -834,7 +834,7 @@ func TestGetPayloadCapella(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	require.Equal(t, 1, backend.relays[0].GetRequestCount(getPayloadPath))
 
-	resp := new(api.VersionedSubmitBlindedBlockResponse)
+	resp := new(builderApi.VersionedSubmitBlindedBlockResponse)
 	err = json.Unmarshal(rr.Body.Bytes(), resp)
 	require.NoError(t, err)
 	require.Equal(t, signedBlindedBeaconBlock.Message.Body.ExecutionPayloadHeader.BlockHash, resp.Capella.BlockHash)
@@ -845,14 +845,14 @@ func TestGetPayloadDeneb(t *testing.T) {
 	jsonFile, err := os.Open("../testdata/signed-blinded-beacon-block-deneb.json")
 	require.NoError(t, err)
 	defer jsonFile.Close()
-	signedBlindedBlockContents := new(apiv1deneb.SignedBlindedBlockContents)
+	signedBlindedBlockContents := new(eth2ApiV1Deneb.SignedBlindedBlockContents)
 	require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBlockContents))
 
 	backend := newTestBackend(t, 1, time.Second)
 
 	// Prepare getPayload response
-	backend.relays[0].GetPayloadResponse = &api.VersionedSubmitBlindedBlockResponse{
-		Version: consensusspec.DataVersionDeneb,
+	backend.relays[0].GetPayloadResponse = &builderApi.VersionedSubmitBlindedBlockResponse{
+		Version: spec.DataVersionDeneb,
 		Deneb:   blindedBlockContentsToBlockContentsDeneb(signedBlindedBlockContents),
 	}
 
@@ -862,7 +862,7 @@ func TestGetPayloadDeneb(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	require.Equal(t, 1, backend.relays[0].GetRequestCount(getPayloadPath))
 
-	resp := new(api.VersionedSubmitBlindedBlockResponse)
+	resp := new(builderApi.VersionedSubmitBlindedBlockResponse)
 	err = json.Unmarshal(rr.Body.Bytes(), resp)
 	require.NoError(t, err)
 	require.Equal(t, signedBlindedBlockContents.SignedBlindedBlock.Message.Body.ExecutionPayloadHeader.BlockHash, resp.Deneb.ExecutionPayload.BlockHash)
@@ -873,7 +873,7 @@ func TestGetPayloadToAllRelays(t *testing.T) {
 	jsonFile, err := os.Open("../testdata/signed-blinded-beacon-block-capella.json")
 	require.NoError(t, err)
 	defer jsonFile.Close()
-	signedBlindedBeaconBlock := new(apiv1capella.SignedBlindedBeaconBlock)
+	signedBlindedBeaconBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
 	require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBeaconBlock))
 
 	// Create a test backend with 2 relays
@@ -886,7 +886,7 @@ func TestGetPayloadToAllRelays(t *testing.T) {
 		"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
 		"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
 		"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
-		consensusspec.DataVersionCapella,
+		spec.DataVersionCapella,
 	)
 	rr := backend.request(t, http.MethodGet, getHeaderPath, nil)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
@@ -894,8 +894,8 @@ func TestGetPayloadToAllRelays(t *testing.T) {
 	require.Equal(t, 1, backend.relays[1].GetRequestCount(getHeaderPath))
 
 	// Prepare getPayload response
-	backend.relays[0].GetPayloadResponse = &api.VersionedSubmitBlindedBlockResponse{
-		Version: consensusspec.DataVersionCapella,
+	backend.relays[0].GetPayloadResponse = &builderApi.VersionedSubmitBlindedBlockResponse{
+		Version: spec.DataVersionCapella,
 		Capella: blindedBlockToExecutionPayloadCapella(signedBlindedBeaconBlock),
 	}
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
@@ -170,7 +170,7 @@ func GetURI(url *url.URL, path string) string {
 // bidResp are entries in the bids cache
 type bidResp struct {
 	t        time.Time
-	response spec.VersionedSignedBuilderBid
+	response builderSpec.VersionedSignedBuilderBid
 	bidInfo  bidInfo
 	relays   []RelayEntry
 }
@@ -261,7 +261,7 @@ func executionPayloadToBlockHeader(payload *capella.ExecutionPayload) (*types.He
 	}, nil
 }
 
-func parseBidInfo(bid *spec.VersionedSignedBuilderBid) (bidInfo, error) {
+func parseBidInfo(bid *builderSpec.VersionedSignedBuilderBid) (bidInfo, error) {
 	blockHash, err := bid.BlockHash()
 	if err != nil {
 		return bidInfo{}, err
@@ -297,7 +297,7 @@ func parseBidInfo(bid *spec.VersionedSignedBuilderBid) (bidInfo, error) {
 	return bidInfo, nil
 }
 
-func checkRelaySignature(bid *spec.VersionedSignedBuilderBid, domain phase0.Domain, pubKey phase0.BLSPubKey) (bool, error) {
+func checkRelaySignature(bid *builderSpec.VersionedSignedBuilderBid, domain phase0.Domain, pubKey phase0.BLSPubKey) (bool, error) {
 	root, err := bid.MessageHashTreeRoot()
 	if err != nil {
 		return false, err
@@ -315,19 +315,19 @@ func checkRelaySignature(bid *spec.VersionedSignedBuilderBid, domain phase0.Doma
 	return bls.VerifySignatureBytes(msg[:], sig[:], pubKey[:])
 }
 
-func getPayloadResponseIsEmpty(payload *api.VersionedSubmitBlindedBlockResponse) bool {
+func getPayloadResponseIsEmpty(payload *builderApi.VersionedSubmitBlindedBlockResponse) bool {
 	switch payload.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		if payload.Capella == nil || payload.Capella.BlockHash == nilHash {
 			return true
 		}
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		if payload.Deneb == nil || payload.Deneb.ExecutionPayload == nil ||
 			payload.Deneb.ExecutionPayload.BlockHash == nilHash ||
 			payload.Deneb.BlobsBundle == nil || payload.Deneb.BlobsBundle.Blobs == nil {
 			return true
 		}
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return true
 	}
 	return false


### PR DESCRIPTION
## 📝 Summary

Rename imports for `github.com/attestantio/*` to be more consistent. Decided to go with camelCase instead of all lowercase just for improved readability; if there were fewer words I would have loved to make it all lowercase.

1. All of the `go-eth2-client/spec` imports will be unnamed.
<img src="https://github.com/flashbots/mev-boost/assets/95511699/9c557680-9abc-484f-83a5-27f55536914a" width="500">

2. All of the `go-eth2-client/api/v*/<spec>` imports will match this style:
<img src="https://github.com/flashbots/mev-boost/assets/95511699/9a620da6-8c1e-4666-a5c7-9762ac896c33" width="500">

3. All of the `go-eth2-client/util/<spec>` imports will match this style:
<img src="https://github.com/flashbots/mev-boost/assets/95511699/4719b1e7-820d-4c39-96b6-b0048d93b73c" width="500">

4. All of the `go-builder-client` imports will match their path names sequentially:
<img src="https://github.com/flashbots/mev-boost/assets/95511699/f13d97d5-3764-4ea8-94c0-a0f2909cd1b1" width="500">

## ⛱ Motivation and Context

This has been a small pet-peeve of mine for a while. Due to a lot of overlapping package names, we were required to rename some imports. This wasn't very consistent. This PR aims to make things consistent.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
