### PR TITLE
Add holesky network details and flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ go run . -h
 ./mev-boost -goerli -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
-Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-goerli`/`-sepolia`).
+Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-goerli`/`-sepolia`/`-holesky`).
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See also:
   - [Mainnet](#mainnet)
   - [Goerli testnet](#goerli-testnet)
   - [Sepolia testnet](#sepolia-testnet)
+  - [Holesky testnet](#holesky-testnet)
   - [`test-cli`](#test-cli)
   - [mev-boost cli arguments](#mev-boost-cli-arguments)
 - [API](#api)
@@ -211,6 +212,14 @@ Run MEV-Boost pointed at a Sepolia relay:
 ./mev-boost -sepolia -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
+## Holesky testnet
+
+Run MEV-Boost pointed at a Holesky relay:
+
+```
+./mev-boost -holesky -relay-check -relay URL-OF-TRUSTED-RELAY
+```
+
 ## `test-cli`
 
 `test-cli` is a utility to execute all proposer requests against MEV-Boost + relay. See also the [test-cli readme](cmd/test-cli/README.md).
@@ -231,6 +240,8 @@ Usage of mev-boost:
         use a custom genesis fork version
   -goerli
         use Goerli
+  -holesky
+        use Holesky
   -json
         log in JSON format instead of text
   -log-no-version
@@ -301,7 +312,6 @@ Example for setting a minimum bid value of 0.06 ETH:
     -relay $YOUR_RELAY_CHOICE_B \
     -relay $YOUR_RELAY_CHOICE_C
 ```
-
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,7 +65,7 @@ git push origin --tags
 docker pull flashbots/mev-boost:v1.9a1
 ```
 
-## Ask node operators to test this RC (on Goerli or Sepolia)
+## Ask node operators to test this RC (on Goerli or Sepolia or Holesky)
 
 * Reach out to node operators to help test this release
 * Collect their sign-off for the release

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -17,13 +18,18 @@ const (
 	genesisForkVersionMainnet = "0x00000000"
 	genesisForkVersionSepolia = "0x90000069"
 	genesisForkVersionGoerli  = "0x00001020"
+	genesisForkVersionHolesky = "0x01017000"
 
-	genesisTimeMainnet uint64 = 1606824023
-	genesisTimeSepolia uint64 = 1655733600
-	genesisTimeGoerli  uint64 = 1614588812
+	genesisTimeMainnet = 1606824023
+	genesisTimeSepolia = 1655733600
+	genesisTimeGoerli  = 1614588812
+	genesisTimeHolesky = 1630440000
 )
 
 var (
+	// errors
+	errInvalidLoglevel = errors.New("invalid loglevel")
+
 	// defaults
 	defaultLogJSON           = os.Getenv("LOG_JSON") != ""
 	defaultLogLevel          = common.GetEnv("LOG_LEVEL", "info")
@@ -41,6 +47,7 @@ var (
 	defaultGenesisTime        = common.GetEnvInt("GENESIS_TIMESTAMP", -1)
 	defaultUseSepolia         = os.Getenv("SEPOLIA") != ""
 	defaultUseGoerli          = os.Getenv("GOERLI") != ""
+	defaultUseHolesky         = os.Getenv("HOLESKY") != ""
 
 	// mev-boost relay request timeouts (see also https://github.com/flashbots/mev-boost/issues/287)
 	defaultTimeoutMsGetHeader         = common.GetEnvInt("RELAY_TIMEOUT_MS_GETHEADER", 950)   // timeout for getHeader requests
@@ -74,6 +81,7 @@ var (
 	mainnet = flag.Bool("mainnet", true, "use Mainnet")
 	sepolia = flag.Bool("sepolia", defaultUseSepolia, "use Sepolia")
 	goerli  = flag.Bool("goerli", defaultUseGoerli, "use Goerli")
+	holesky = flag.Bool("holesky", defaultUseHolesky, "use Holesky")
 
 	useCustomGenesisForkVersion = flag.String("genesis-fork-version", defaultGenesisForkVersion, "use a custom genesis fork version")
 	useCustomGenesisTime        = flag.Int("genesis-timestamp", defaultGenesisTime, "use a custom genesis timestamp (unix seconds)")
@@ -96,42 +104,11 @@ func Main() {
 		return
 	}
 
-	// setup logging
-	log.Logger.SetOutput(os.Stdout)
-	if *logJSON {
-		log.Logger.SetFormatter(&logrus.JSONFormatter{
-			TimestampFormat: config.RFC3339Milli,
-		})
-	} else {
-		log.Logger.SetFormatter(&logrus.TextFormatter{
-			FullTimestamp:   true,
-			TimestampFormat: config.RFC3339Milli,
-		})
+	err := setupLogging()
+	if err != nil {
+		flag.Usage()
+		log.WithError(err).Fatal("failed setting up logging")
 	}
-	if *logDebug {
-		*logLevel = "debug"
-	}
-	if *logLevel != "" {
-		lvl, err := logrus.ParseLevel(*logLevel)
-		if err != nil {
-			flag.Usage()
-			log.Fatalf("invalid loglevel: %s", *logLevel)
-		}
-		log.Logger.SetLevel(lvl)
-	}
-	if *logService != "" {
-		log = log.WithField("service", *logService)
-	}
-
-	// Add version to logs and say hello
-	addVersionToLogs := !*logNoVersion
-	if addVersionToLogs {
-		log = log.WithField("version", config.Version)
-		log.Infof("starting mev-boost")
-	} else {
-		log.Infof("starting mev-boost %s", config.Version)
-	}
-	log.Debug("debug logging enabled")
 
 	genesisForkVersionHex := ""
 	var genesisTime uint64
@@ -145,12 +122,15 @@ func Main() {
 	case *goerli:
 		genesisForkVersionHex = genesisForkVersionGoerli
 		genesisTime = genesisTimeGoerli
+	case *holesky:
+		genesisForkVersionHex = genesisForkVersionHolesky
+		genesisTime = genesisTimeHolesky
 	case *mainnet:
 		genesisForkVersionHex = genesisForkVersionMainnet
 		genesisTime = genesisTimeMainnet
 	default:
 		flag.Usage()
-		log.Fatal("please specify a genesis fork version (eg. -mainnet / -sepolia / -goerli / -genesis-fork-version flags)")
+		log.Fatal("please specify a genesis fork version (eg. -mainnet / -sepolia / -goerli / -holesky / -genesis-fork-version flags)")
 	}
 	log.Infof("using genesis fork version: %s", genesisForkVersionHex)
 
@@ -236,4 +216,43 @@ func Main() {
 
 	log.Println("listening on", *listenAddr)
 	log.Fatal(service.StartHTTPServer())
+}
+
+func setupLogging() error {
+	// setup logging
+	log.Logger.SetOutput(os.Stdout)
+	if *logJSON {
+		log.Logger.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: config.RFC3339Milli,
+		})
+	} else {
+		log.Logger.SetFormatter(&logrus.TextFormatter{
+			FullTimestamp:   true,
+			TimestampFormat: config.RFC3339Milli,
+		})
+	}
+	if *logDebug {
+		*logLevel = "debug"
+	}
+	if *logLevel != "" {
+		lvl, err := logrus.ParseLevel(*logLevel)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errInvalidLoglevel, *logLevel)
+		}
+		log.Logger.SetLevel(lvl)
+	}
+	if *logService != "" {
+		log = log.WithField("service", *logService)
+	}
+
+	// Add version to logs and say hello
+	addVersionToLogs := !*logNoVersion
+	if addVersionToLogs {
+		log = log.WithField("version", config.Version)
+		log.Infof("starting mev-boost")
+	} else {
+		log.Infof("starting mev-boost %s", config.Version)
+	}
+	log.Debug("debug logging enabled")
+	return nil
 }


### PR DESCRIPTION
## 📝 Summary

This PR adds support for the holesky testnet as the holesky relay at https://boost-relay-holesky.flashbots.net/ is up now.

## ⛱ Motivation and Context

This provides native support for validators on holesky to test mev-boost and the relay.

## 📚 References

See [holesky testnet](https://github.com/eth-clients/holesky) for network details.

---

## ✅ I have run these commands

* [x] `make lint`
* [x]  `make test-race`
* [x] `go mod tidy`
