### PR TITLE
fix: holesky genesis timestamp

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -23,7 +23,7 @@ const (
 	genesisTimeMainnet = 1606824023
 	genesisTimeSepolia = 1655733600
 	genesisTimeGoerli  = 1614588812
-	genesisTimeHolesky = 1630440000
+	genesisTimeHolesky = 1695902400
 )
 
 var (


### PR DESCRIPTION
## 📝 Summary

The current Holesky genesis timestamp used in MEV boost is not correct.

## ⛱ Motivation and Context

This prevents usage of mev-boost under the Holesky network.

## 📚 References

Genesis can be found here: https://holesky.beaconcha.in/slot/0

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
