### PR TITLE
Set defaultRelayMinBidEth to 0.05 ETH

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -35,7 +35,7 @@ var (
 	defaultLogLevel          = common.GetEnv("LOG_LEVEL", "info")
 	defaultListenAddr        = common.GetEnv("BOOST_LISTEN_ADDR", "localhost:18550")
 	defaultRelayCheck        = os.Getenv("RELAY_STARTUP_CHECK") != ""
-	defaultRelayMinBidEth    = common.GetEnvFloat64("MIN_BID_ETH", 0)
+	defaultRelayMinBidEth    = common.GetEnvFloat64("MIN_BID_ETH", 0.05)
 	defaultDisableLogVersion = os.Getenv("DISABLE_LOG_VERSION") == "1" // disables adding the version to every log entry
 	defaultDebug             = os.Getenv("DEBUG") != ""
 	defaultLogServiceTag     = os.Getenv("LOG_SERVICE_TAG")


### PR DESCRIPTION
## 📝 Summary

Defaults are powerful, and setting a non-zero `defaultRelayMinBid` can help increase censorship resistance. 

## ⛱ Motivation, Context and References

`defaultRelayMinBid` is a valuable feature to improve Ethereum's censorship resistance, but is currently off by default. 

In Nov 2022, a 0.05 ETH `MinBid` was shown to result in validators proposing ~50% of blocks locally while keeping 80% of total fees ([source](https://twitter.com/VitalikButerin/status/1595793106926014466)). With a majority of builders currently censoring transactions ([source](https://censorship.pics/)), setting a non-zero default for this value can help increase the overall censorship resistance of the network. 

While anyone can opt-out of this change trivially by setting the flag themselves, given mev-boost's broad adoption, many users are likely to stick to the defaults. 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
