### PR TITLE
Add request start time metrics to request header field

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -257,6 +257,11 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 		"ua":               ua,
 	})
 
+	// Add request headers
+	headers := map[string]string{
+		HeaderStartTimeMsUnix: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
+	}
+
 	relayRespCh := make(chan error, len(m.relays))
 
 	for _, relay := range m.relays {
@@ -264,7 +269,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 			url := relay.GetURI(params.PathRegisterValidator)
 			log := log.WithField("url", url)
 
-			_, err := SendHTTPRequest(context.Background(), m.httpClientRegVal, http.MethodPost, url, ua, nil, payload, nil)
+			_, err := SendHTTPRequest(context.Background(), m.httpClientRegVal, http.MethodPost, url, ua, headers, payload, nil)
 			relayRespCh <- err
 			if err != nil {
 				log.WithError(err).Warn("error calling registerValidator on relay")
@@ -342,6 +347,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	headers := map[string]string{
 		HeaderKeySlotUID:          slotUID.String(),
 		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
+		HeaderStartTimeMsUnix:     fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
 	// Prepare relay responses
@@ -672,6 +678,7 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 	headers := map[string]string{
 		HeaderKeySlotUID:          currentSlotUID,
 		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
+		HeaderStartTimeMsUnix:     fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
 	// Prepare for requests

--- a/server/service.go
+++ b/server/service.go
@@ -340,7 +340,8 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 
 	// Add request headers
 	headers := map[string]string{
-		HeaderKeySlotUID: slotUID.String(),
+		HeaderKeySlotUID:          slotUID.String(),
+		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
 	}
 
 	// Prepare relay responses
@@ -668,7 +669,10 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 	}
 
 	// Add request headers
-	headers := map[string]string{HeaderKeySlotUID: currentSlotUID}
+	headers := map[string]string{
+		HeaderKeySlotUID:          currentSlotUID,
+		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
+	}
 
 	// Prepare for requests
 	var wg sync.WaitGroup

--- a/server/service.go
+++ b/server/service.go
@@ -259,7 +259,7 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 
 	// Add request headers
 	headers := map[string]string{
-		HeaderStartTimeMsUnix: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
+		HeaderStartTimeUnixMS: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
 	relayRespCh := make(chan error, len(m.relays))
@@ -344,8 +344,8 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	}).Infof("getHeader request start - %d milliseconds into slot %d", msIntoSlot, _slot)
 	// Add request headers
 	headers := map[string]string{
-		HeaderKeySlotUID:          slotUID.String(),
-		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
+		HeaderKeySlotUID:      slotUID.String(),
+		HeaderStartTimeUnixMS: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 	// Prepare relay responses
 	result := bidResp{}                                 // the final response, containing the highest bid (if any)
@@ -671,8 +671,8 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 
 	// Add request headers
 	headers := map[string]string{
-		HeaderKeySlotUID:          currentSlotUID,
-		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
+		HeaderKeySlotUID:      currentSlotUID,
+		HeaderStartTimeUnixMS: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
 	// Prepare for requests

--- a/server/service.go
+++ b/server/service.go
@@ -346,7 +346,6 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	headers := map[string]string{
 		HeaderKeySlotUID:          slotUID.String(),
 		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
-		HeaderStartTimeMsUnix:     fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 	// Prepare relay responses
 	result := bidResp{}                                 // the final response, containing the highest bid (if any)
@@ -674,7 +673,6 @@ func (m *BoostService) processDenebPayload(w http.ResponseWriter, req *http.Requ
 	headers := map[string]string{
 		HeaderKeySlotUID:          currentSlotUID,
 		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
-		HeaderStartTimeMsUnix:     fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
 	// Prepare for requests

--- a/server/service.go
+++ b/server/service.go
@@ -343,18 +343,15 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		"msIntoSlot":  msIntoSlot,
 	}).Infof("getHeader request start - %d milliseconds into slot %d", msIntoSlot, _slot)
 
-	// Add request headers
 	headers := map[string]string{
 		HeaderKeySlotUID:          slotUID.String(),
 		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
 		HeaderStartTimeMsUnix:     fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
-	// Prepare relay responses
 	result := bidResp{}                                 // the final response, containing the highest bid (if any)
 	relays := make(map[BlockHashHex][]types.RelayEntry) // relays that sent the bid for a specific blockHash
 
-	// Call the relays
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	for _, relay := range m.relays {
@@ -478,7 +475,6 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	// Log result
 	valueEth := weiBigIntToEthBigFloat(result.bidInfo.value.ToBig())
 	result.relays = relays[BlockHashHex(result.bidInfo.blockHash.String())]
 	log.WithFields(logrus.Fields{

--- a/server/service.go
+++ b/server/service.go
@@ -342,16 +342,16 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		"slotTimeSec": config.SlotTimeSec,
 		"msIntoSlot":  msIntoSlot,
 	}).Infof("getHeader request start - %d milliseconds into slot %d", msIntoSlot, _slot)
-
+	// Add request headers
 	headers := map[string]string{
 		HeaderKeySlotUID:          slotUID.String(),
 		HeaderStartTimeMsIntoSlot: fmt.Sprintf("%d", msIntoSlot),
 		HeaderStartTimeMsUnix:     fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
-
+	// Prepare relay responses
 	result := bidResp{}                                 // the final response, containing the highest bid (if any)
 	relays := make(map[BlockHashHex][]types.RelayEntry) // relays that sent the bid for a specific blockHash
-
+	// Call the relays
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	for _, relay := range m.relays {
@@ -465,7 +465,6 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 			result.t = time.Now()
 		}(relay)
 	}
-
 	// Wait for all requests to complete...
 	wg.Wait()
 
@@ -475,6 +474,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	// Log result
 	valueEth := weiBigIntToEthBigFloat(result.bidInfo.value.ToBig())
 	result.relays = relays[BlockHashHex(result.bidInfo.blockHash.String())]
 	log.WithFields(logrus.Fields{

--- a/server/utils.go
+++ b/server/utils.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	HeaderKeySlotUID = "X-MEVBoost-SlotID"
-	HeaderKeyVersion = "X-MEVBoost-Version"
+	HeaderKeySlotUID          = "X-MEVBoost-SlotID"
+	HeaderKeyVersion          = "X-MEVBoost-Version"
+	HeaderStartTimeMsIntoSlot = "X-MEVBoost-StartTimeMSIntoSlot"
 )
 
 var (

--- a/server/utils.go
+++ b/server/utils.go
@@ -27,10 +27,9 @@ import (
 )
 
 const (
-	HeaderKeySlotUID          = "X-MEVBoost-SlotID"
-	HeaderKeyVersion          = "X-MEVBoost-Version"
-	HeaderStartTimeMsUnix     = "X-MEVBoost-StartTimeMSUnix"
-	HeaderStartTimeMsIntoSlot = "X-MEVBoost-StartTimeMSIntoSlot"
+	HeaderKeySlotUID      = "X-MEVBoost-SlotID"
+	HeaderKeyVersion      = "X-MEVBoost-Version"
+	HeaderStartTimeUnixMS = "X-MEVBoost-StartTimeUnixMS"
 )
 
 var (

--- a/server/utils.go
+++ b/server/utils.go
@@ -29,6 +29,7 @@ import (
 const (
 	HeaderKeySlotUID          = "X-MEVBoost-SlotID"
 	HeaderKeyVersion          = "X-MEVBoost-Version"
+	HeaderStartTimeMsUnix     = "X-MEVBoost-StartTimeMSUnix"
 	HeaderStartTimeMsIntoSlot = "X-MEVBoost-StartTimeMSIntoSlot"
 )
 


### PR DESCRIPTION
## 📝 Summary
This PR introduces the ability to add the request start time in Unix milliseconds and the start time into the slot to the request headers. This enhancement facilitates the measurement of latency between the validator and the relay.

## ⛱ Motivation and Context
By adding these time metrics into the headers, we can better analyze the causes of request delays, determining whether they are due to network latency or performance issues with the validator node.


## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
