### PR TITLE
Fix duplicate GENESIS_FORK_VERSION env flag

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -98,7 +98,7 @@ var (
 	}
 	mainnetFlag = &cli.BoolFlag{
 		Name:     "mainnet",
-		Sources:  cli.EnvVars("GENESIS_FORK_VERSION"),
+		Sources:  cli.EnvVars("MAINNET"),
 		Usage:    "use Mainnet",
 		Value:    true,
 		Category: GenesisCategory,


### PR DESCRIPTION
## 📝 Summary

This PR resolves the issue of duplicate GENESIS_FORK_VERSION env flag.

## ⛱ Motivation and Context

GENESIS_FORK_VERSION environment flag was being used in two different places, leading to conflicting env values.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
