### PR TITLE
main: remove symlink

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,1 +1,7 @@
-cmd/mev-boost/main.go
+package main
+
+import "github.com/flashbots/mev-boost/cli"
+
+func main() {
+	cli.Main()
+}


### PR DESCRIPTION
This should fix https://github.com/flashbots/mev-boost/issues/678
During the last refactor I added a symlink from main.go -> cmd/mev-boost/main.go
Seems like go install has an issue when working with symlinks

Alternatively, since we already broke users, we could just get rid of the symlink and force everyone to `go install github.com/flashbots/mev-boost/cmd/mev-boost@latest`