### PR TITLE
Release the RISC-V binary.

### DIFF
--- a/.goreleaser-build.yaml
+++ b/.goreleaser-build.yaml
@@ -22,3 +22,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
+    ignore:
+      - goos: darwin
+        goarch: riscv64
+      - goos: windows
+        goarch: riscv64


### PR DESCRIPTION
Part of #681.

## 📝 Summary

I've added risc-v to the goreleaser configuration.

## ⛱ Motivation and Context

This will enable the community to alpha test mev-boost in risc-v boards.

## 📚 References

[<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->](https://collective.flashbots.net/t/open-hardware/3810#p-8081-risc-v-2)

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`

I build and ran the unit tests in a risc-v qemu.
With cloud-v we are setting up a jenkins project to build and test ethereum clients:
https://dash.cloud-v.co/view/all/job/github_app_come-maiz_165147473562/