### PR TITLE
chore: add `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# General settings
+BOOST_LISTEN_ADDR=localhost:18550        # Listen address for mev-boost server
+
+# Logging and debugging settings
+LOG_JSON=false                           # Set to true to log in JSON format instead of text
+DEBUG=false                              # Set to true to enable debug mode (shorthand for '--loglevel debug')
+LOG_LEVEL=info                           # Log level: trace, debug, info, warn/warning, error, fatal, panic
+LOG_SERVICE_TAG=                         # Optional: add a 'service=...' tag to all log messages
+DISABLE_LOG_VERSION=false                # Set to true to disable logging the version
+
+# Genesis settings
+GENESIS_FORK_VERSION=                    # Custom genesis fork version (optional)
+GENESIS_TIMESTAMP=-1                     # Custom genesis timestamp (in unix seconds)
+MAINNET=true                             # Set to true to use Mainnet
+SEPOLIA=false                            # Set to true to use Sepolia network
+HOLESKY=false                            # Set to true to use Holesky network
+
+# Relay settings
+RELAYS=                                  # Relay URLs: single entry or comma-separated list (scheme://pubkey@host)
+RELAY_MONITORS=                          # Relay monitor URLs: single entry or comma-separated list (scheme://host)
+MIN_BID_ETH=0                            # Minimum bid to accept from a relay (in ETH)
+RELAY_STARTUP_CHECK=false                # Set to true to check relay status on startup and on status API call
+
+# Relay timeout settings (in ms)
+RELAY_TIMEOUT_MS_GETHEADER=950           # Timeout for getHeader requests to the relay (in ms)
+RELAY_TIMEOUT_MS_GETPAYLOAD=4000         # Timeout for getPayload requests to the relay (in ms)
+RELAY_TIMEOUT_MS_REGVAL=3000             # Timeout for registerValidator requests (in ms)
+
+# Retry settings
+REQUEST_MAX_RETRIES=5                    # Maximum number of retries for a relay get payload request

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@
 /README.internal.md
 /validator_data.json
 /build/
+
+# Environemnt variable files
+.env*
+!.env.example
+


### PR DESCRIPTION
## 📝 Summary

This PR just introduces a `.env.example` file and updates the `.gitignore` file to exclude `*.env` files excluding the example one.

## ⛱ Motivation and Context

I personally find it useful having a `.env.example` when I have to launch the service in a docker compose setup.

