### PR TITLE
fix: customGenesisForkFlag not works

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -158,7 +158,7 @@ func setupGenesis(cmd *cli.Command) (string, uint64) {
 	)
 
 	switch {
-	case cmd.Bool(customGenesisForkFlag.Name):
+	case cmd.IsSet(customGenesisForkFlag.Name):
 		genesisForkVersion = cmd.String(customGenesisForkFlag.Name)
 	case cmd.Bool(sepoliaFlag.Name):
 		genesisForkVersion = genesisForkVersionSepolia


### PR DESCRIPTION
## 📝 Summary

close: https://github.com/flashbots/mev-boost/issues/705

tested in local:
![image](https://github.com/user-attachments/assets/89a21ba3-189a-4fd5-846c-f3c79de298cb)

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
