### PR TITLE
fix linter issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         run: go install mvdan.cc/gofumpt@v0.6.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
 
       - name: Lint
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,11 +9,9 @@ linters:
     - gocritic
     - godot
     - godox
-    - gomnd
     - lll
     - nlreturn
     - nonamedreturns
-    - nosnakecase
     - paralleltest
     - testpackage
     - varnamelen
@@ -40,20 +38,12 @@ linters:
     - contextcheck
     - rowserrcheck
     - sqlclosecheck
-    - structcheck
     - wastedassign
 
     #
     # Disabled because deprecated:
     #
-    - deadcode
-    - exhaustivestruct
-    - golint
-    - ifshort
-    - interfacer
-    - maligned
-    - scopelint
-    - varcheck
+
 
 linters-settings:
   gofumpt:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - godot
     - godox
     - lll
+    - mnd
     - nlreturn
     - nonamedreturns
     - paralleltest
@@ -43,6 +44,13 @@ linters:
     #
     # Disabled because deprecated:
     #
+    - copyloopvar
+
+    #
+    # Disabled due to versioning:
+    #
+    - intrange
+    - exportloopref
 
 
 linters-settings:

--- a/server/service.go
+++ b/server/service.go
@@ -230,7 +230,7 @@ func (m *BoostService) handleRoot(w http.ResponseWriter, _ *http.Request) {
 // handleStatus sends calls to the status endpoint of every relay.
 // It returns OK if at least one returned OK, and returns error otherwise.
 func (m *BoostService) handleStatus(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set(HeaderKeyVersion, config.Version)
+	w.Header().Set(HeaderKeyVersion, config.Version) //nolint:canonicalheader // we use a non-canonical header
 	if !m.relayCheck || m.CheckRelays() > 0 {
 		m.respondOK(w, nilResponse)
 	} else {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -269,7 +269,7 @@ func TestRegisterValidator(t *testing.T) {
 			w.WriteHeader(http.StatusBadRequest)
 		})
 		rr = backend.request(t, http.MethodPost, path, payload)
-		require.Equal(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadGateway, rr.Code)
 		require.Equal(t, 3, backend.relays[0].GetRequestCount(path))
 		require.Equal(t, 3, backend.relays[1].GetRequestCount(path))
@@ -283,7 +283,7 @@ func TestRegisterValidator(t *testing.T) {
 		// Now make the relay return slowly, mev-boost should return an error
 		backend.relays[0].ResponseDelay = 180 * time.Millisecond
 		rr = backend.request(t, http.MethodPost, path, payload)
-		require.Equal(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadGateway, rr.Code)
 		require.Equal(t, 2, backend.relays[0].GetRequestCount(path))
 	})
@@ -398,7 +398,7 @@ func TestGetHeader(t *testing.T) {
 
 		backend := newTestBackend(t, 1, time.Second)
 		rr := backend.request(t, http.MethodGet, invalidSlotPath, nil)
-		require.Equal(t, `{"code":400,"message":"invalid slot"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":400,"message":"invalid slot"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
@@ -408,7 +408,7 @@ func TestGetHeader(t *testing.T) {
 
 		backend := newTestBackend(t, 1, time.Second)
 		rr := backend.request(t, http.MethodGet, invalidPubkeyPath, nil)
-		require.Equal(t, `{"code":400,"message":"invalid pubkey"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":400,"message":"invalid pubkey"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
@@ -418,7 +418,7 @@ func TestGetHeader(t *testing.T) {
 
 		backend := newTestBackend(t, 1, time.Second)
 		rr := backend.request(t, http.MethodGet, invalidSlotPath, nil)
-		require.Equal(t, `{"code":400,"message":"invalid hash"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":400,"message":"invalid hash"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
@@ -667,7 +667,7 @@ func TestGetPayload(t *testing.T) {
 		rr = backend.request(t, http.MethodPost, path, payload)
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 		require.Equal(t, 1, backend.relays[1].GetRequestCount(path))
-		require.Equal(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadGateway, rr.Code, rr.Body.String())
 	})
 
@@ -709,7 +709,7 @@ func TestGetPayload(t *testing.T) {
 		})
 		rr := backend.request(t, http.MethodPost, path, payload)
 		require.Equal(t, 5, backend.relays[0].GetRequestCount(path))
-		require.Equal(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
+		require.JSONEq(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
 		require.Equal(t, http.StatusBadGateway, rr.Code, rr.Body.String())
 	})
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -206,7 +206,7 @@ func TestStatus(t *testing.T) {
 		rr := backend.request(t, http.MethodGet, path, nil)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Greater(t, len(rr.Header().Get("X-MEVBoost-Version")), 0) //nolint:testifylint
+		require.Greater(t, len(rr.Header().Get("X-MEVBoost-Version")), 0) //nolint:canonicalheader // we use a non-canonical header
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
@@ -218,7 +218,7 @@ func TestStatus(t *testing.T) {
 		rr := backend.request(t, http.MethodGet, path, nil)
 
 		require.Equal(t, http.StatusServiceUnavailable, rr.Code)
-		require.Greater(t, len(rr.Header().Get("X-MEVBoost-Version")), 0) //nolint:testifylint
+		require.Greater(t, len(rr.Header().Get("X-MEVBoost-Version")), 0) //nolint:canonicalheader // we use a non-canonical header
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -682,7 +682,7 @@ func TestGetPayload(t *testing.T) {
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, err := w.Write([]byte(`{"code":500,"message":"internal server error"}`))
-				require.NoError(t, err)
+				require.NoError(t, err, "failed to write error response") //nolint:testifylint // if we fail here the test is compromised
 			}
 			count++
 		})
@@ -704,7 +704,7 @@ func TestGetPayload(t *testing.T) {
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, err := w.Write([]byte(`{"code":500,"message":"internal server error"}`))
-				require.NoError(t, err)
+				require.NoError(t, err, "failed to write error response") //nolint:testifylint // if we fail here the test is compromised
 			}
 		})
 		rr := backend.request(t, http.MethodPost, path, payload)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -206,7 +206,7 @@ func TestStatus(t *testing.T) {
 		rr := backend.request(t, http.MethodGet, path, nil)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Greater(t, len(rr.Header().Get("X-MEVBoost-Version")), 0) //nolint:canonicalheader // we use a non-canonical header
+		require.NotEmpty(t, rr.Header().Get("X-MEVBoost-Version")) //nolint:canonicalheader // we use a non-canonical header
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
@@ -218,7 +218,7 @@ func TestStatus(t *testing.T) {
 		rr := backend.request(t, http.MethodGet, path, nil)
 
 		require.Equal(t, http.StatusServiceUnavailable, rr.Code)
-		require.Greater(t, len(rr.Header().Get("X-MEVBoost-Version")), 0) //nolint:canonicalheader // we use a non-canonical header
+		require.NotEmpty(t, rr.Header().Get("X-MEVBoost-Version")) //nolint:canonicalheader // we use a non-canonical header
 		require.Equal(t, 0, backend.relays[0].GetRequestCount(path))
 	})
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -46,7 +46,7 @@ func TestSendHTTPRequestUserAgent(t *testing.T) {
 	customUA := "test-user-agent"
 	expectedUA := fmt.Sprintf("mev-boost/%s %s", config.Version, customUA)
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		require.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		require.Equal(t, expectedUA, r.Header.Get("User-Agent")) //nolint:testifylint // if we fail here the test has failed
 		done <- true
 	}))
 	code, err := SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, ts.URL, UserAgent(customUA), nil, nil, nil)
@@ -58,7 +58,7 @@ func TestSendHTTPRequestUserAgent(t *testing.T) {
 	// Test without custom UA
 	expectedUA = fmt.Sprintf("mev-boost/%s", config.Version)
 	ts = httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		require.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		require.Equal(t, expectedUA, r.Header.Get("User-Agent")) //nolint:testifylint  // if we fail here the test has failed
 		done <- true
 	}))
 	code, err = SendHTTPRequest(context.Background(), *http.DefaultClient, http.MethodGet, ts.URL, "", nil, nil, nil)
@@ -77,7 +77,7 @@ func TestSendHTTPRequestGzip(t *testing.T) {
 	require.NoError(t, zw.Close())
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+		require.Equal(t, "gzip", r.Header.Get("Accept-Encoding")) //nolint:testifylint // if this fails the test is invalid
 		w.Header().Set("Content-Encoding", "gzip")
 		_, _ = w.Write(buf.Bytes())
 	}))


### PR DESCRIPTION
## 📝 Summary

The following PR modifies the golangci.yml config to work with the latest golang-cli.
1. Remove references to deprecated and disabled linters.
2.  It also adds nolint comments where necessary. 
3. Modify some tests to adhere to linters

## ⛱ Motivation and Context

Fixes linting warnings


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
