### PR TITLE
Remove support for relay monitors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ HOLESKY=false                            # Set to true to use Holesky network
 
 # Relay settings
 RELAYS=                                  # Relay URLs: single entry or comma-separated list (scheme://pubkey@host)
-RELAY_MONITORS=                          # Relay monitor URLs: single entry or comma-separated list (scheme://host)
 MIN_BID_ETH=0                            # Minimum bid to accept from a relay (in ETH)
 RELAY_STARTUP_CHECK=false                # Set to true to check relay status on startup and on status API call
 

--- a/README.md
+++ b/README.md
@@ -258,10 +258,6 @@ Usage of mev-boost:
         a single relay, can be specified multiple times
   -relay-check
         check relay status on startup and on the status API call
-  -relay-monitor value
-        a single relay monitor, can be specified multiple times
-  -relay-monitors string
-        relay monitor urls - single entry or comma-separated list (scheme://host)
   -relays string
         relay urls - single entry or comma-separated list (scheme://pubkey@host)
   -request-timeout-getheader int

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,14 +23,13 @@ go mod tidy
 git status # should be no changes
 
 # Start mev-boost with relay check and -relays
-go run . -mainnet -relay-check -min-bid 0.12345 -debug -relays https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io,https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com,https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money
+go run . -mainnet -relay-check -min-bid 0.12345 -debug -relays https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io,https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money
 
 # Start mev-boost with relay check and multiple -relay flags
 go run . -mainnet -relay-check -debug -min-bid 0.12345 \
     -relay https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net \
     -relay https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com \
     -relay https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io \
-    -relay https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com \
     -relay https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money
 
 # Call the status endpoint

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,7 +23,7 @@ go mod tidy
 git status # should be no changes
 
 # Start mev-boost with relay check and -relays
-go run . -mainnet -relay-check -min-bid 0.12345 -debug -relays https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io,https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com,https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money -relay-monitors https://relay-monitor1.example.com,https://relay-monitor2.example.com
+go run . -mainnet -relay-check -min-bid 0.12345 -debug -relays https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io,https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com,https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money
 
 # Start mev-boost with relay check and multiple -relay flags
 go run . -mainnet -relay-check -debug -min-bid 0.12345 \
@@ -31,9 +31,7 @@ go run . -mainnet -relay-check -debug -min-bid 0.12345 \
     -relay https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com \
     -relay https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323b3736f271a895c7ce918c038e4265918be@relay.edennetwork.io \
     -relay https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com \
-    -relay https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money \
-    -relay-monitor https://relay-monitor1.example.com \
-    -relay-monitor https://relay-monitor2.example.com
+    -relay https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money
 
 # Call the status endpoint
 curl localhost:18550/eth/v1/builder/status

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -27,7 +27,7 @@ var flags = []cli.Flag{
 	holeskyFlag,
 	// relay
 	relaysFlag,
-	relayMonitorFlag,
+	deprecatedRelayMonitorFlag,
 	minBidFlag,
 	relayCheckFlag,
 	timeoutGetHeaderFlag,
@@ -123,12 +123,12 @@ var (
 		Usage:    "relay urls - single entry or comma-separated list (scheme://pubkey@host)",
 		Category: RelayCategory,
 	}
-	relayMonitorFlag = &cli.StringSliceFlag{
+	deprecatedRelayMonitorFlag = &cli.StringSliceFlag{
 		Name:     "relay-monitors",
 		Aliases:  []string{"relay-monitor"},
-		Sources:  cli.EnvVars("RELAY_MONITORS"),
-		Usage:    "relay monitor urls - single entry or comma-separated list (scheme://host)",
+		Usage:    "[deprecated]",
 		Category: RelayCategory,
+		Hidden:   true,
 	}
 	minBidFlag = &cli.FloatFlag{
 		Name:     "min-bid",

--- a/cli/types.go
+++ b/cli/types.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"net/url"
 	"strings"
 
 	"github.com/flashbots/mev-boost/server/types"
@@ -34,36 +33,5 @@ func (r *relayList) Set(value string) error {
 		return errDuplicateEntry
 	}
 	*r = append(*r, relay)
-	return nil
-}
-
-type relayMonitorList []*url.URL
-
-func (rm *relayMonitorList) String() string {
-	relayMonitors := []string{}
-	for _, relayMonitor := range *rm {
-		relayMonitors = append(relayMonitors, relayMonitor.String())
-	}
-	return strings.Join(relayMonitors, ",")
-}
-
-func (rm *relayMonitorList) Contains(relayMonitor *url.URL) bool {
-	for _, entry := range *rm {
-		if relayMonitor.String() == entry.String() {
-			return true
-		}
-	}
-	return false
-}
-
-func (rm *relayMonitorList) Set(value string) error {
-	relayMonitor, err := url.Parse(value)
-	if err != nil {
-		return err
-	}
-	if rm.Contains(relayMonitor) {
-		return errDuplicateEntry
-	}
-	*rm = append(*rm, relayMonitor)
 	return nil
 }

--- a/server/service.go
+++ b/server/service.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -60,7 +59,6 @@ type BoostServiceOpts struct {
 	Log                   *logrus.Entry
 	ListenAddr            string
 	Relays                []types.RelayEntry
-	RelayMonitors         []*url.URL
 	GenesisForkVersionHex string
 	GenesisTime           uint64
 	RelayCheck            bool
@@ -74,14 +72,13 @@ type BoostServiceOpts struct {
 
 // BoostService - the mev-boost service
 type BoostService struct {
-	listenAddr    string
-	relays        []types.RelayEntry
-	relayMonitors []*url.URL
-	log           *logrus.Entry
-	srv           *http.Server
-	relayCheck    bool
-	relayMinBid   types.U256Str
-	genesisTime   uint64
+	listenAddr  string
+	relays      []types.RelayEntry
+	log         *logrus.Entry
+	srv         *http.Server
+	relayCheck  bool
+	relayMinBid types.U256Str
+	genesisTime uint64
 
 	builderSigningDomain phase0.Domain
 	httpClientGetHeader  http.Client
@@ -108,15 +105,14 @@ func NewBoostService(opts BoostServiceOpts) (*BoostService, error) {
 	}
 
 	return &BoostService{
-		listenAddr:    opts.ListenAddr,
-		relays:        opts.Relays,
-		relayMonitors: opts.RelayMonitors,
-		log:           opts.Log,
-		relayCheck:    opts.RelayCheck,
-		relayMinBid:   opts.RelayMinBid,
-		genesisTime:   opts.GenesisTime,
-		bids:          make(map[string]bidResp),
-		slotUID:       &slotUID{},
+		listenAddr:  opts.ListenAddr,
+		relays:      opts.Relays,
+		log:         opts.Log,
+		relayCheck:  opts.RelayCheck,
+		relayMinBid: opts.RelayMinBid,
+		genesisTime: opts.GenesisTime,
+		bids:        make(map[string]bidResp),
+		slotUID:     &slotUID{},
 
 		builderSigningDomain: builderSigningDomain,
 		httpClientGetHeader: http.Client{
@@ -246,9 +242,6 @@ func (m *BoostService) handleRegisterValidator(w http.ResponseWriter, req *http.
 		return
 	}
 	req.Body.Close()
-
-	// Send the registrations to relay monitors, if configured
-	go m.sendValidatorRegistrationsToRelayMonitors(log, regBytes, header)
 
 	// Send the registrations to each relay
 	err = m.registerValidator(log, regBytes, header)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -100,7 +100,6 @@ func TestNewBoostServiceErrors(t *testing.T) {
 			Log:                      mock.TestLog,
 			ListenAddr:               ":123",
 			Relays:                   []types.RelayEntry{},
-			RelayMonitors:            []*url.URL{},
 			GenesisForkVersionHex:    "0x00000000",
 			GenesisTime:              0,
 			RelayCheck:               true,


### PR DESCRIPTION
## 📝 Summary

This PR removes all support of relay monitors. The `--relay-monitor` flag is deprecated & hidden, but mev-boost will still function if it's provided, which is important.

```
$ ./mev-boost --relay-monitor=foobar --relay=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
INFO[2025-02-13T15:58:20.939-06:00] starting mev-boost                            version=v1.8.1-27-g9bff7ff
INFO[2025-02-13T15:58:20.94-06:00] using genesis fork version: 0x00000000 time: 1606824023  version=v1.8.1-27-g9bff7ff
INFO[2025-02-13T15:58:20.94-06:00] using 1 relays                                version=v1.8.1-27-g9bff7ff
INFO[2025-02-13T15:58:20.94-06:00] relay #1: https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net  version=v1.8.1-27-g9bff7ff
INFO[2025-02-13T15:58:20.94-06:00] listening on localhost:18550                  version=v1.8.1-27-g9bff7ff
```

## ⛱ Motivation and Context

The relay monitor idea never really took off. We are unaware of anyone using this. Best to remove it.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
