### PR TITLE
Add HeaderDateMilliseconds for improved request timing tracking

### DIFF
--- a/server/constants.go
+++ b/server/constants.go
@@ -6,8 +6,12 @@ const (
 	HeaderEthConsensusVersion = "Eth-Consensus-Version"
 	HeaderKeySlotUID          = "X-MEVBoost-SlotID"
 	HeaderKeyVersion          = "X-MEVBoost-Version"
-	HeaderStartTimeUnixMS     = "X-MEVBoost-StartTimeUnixMS"
-	HeaderUserAgent           = "User-Agent"
+	// Deprecated: replaced by HeaderDateMilliseconds below.
+	HeaderStartTimeUnixMS = "X-MEVBoost-StartTimeUnixMS"
+	HeaderUserAgent       = "User-Agent"
+	// Header which communicates when a request was sent. Used to measure latency.
+	// Replaces HeaderStartTimeUnixMS above which may be dropped in a future release.
+	HeaderDateMilliseconds = "Date-Milliseconds"
 
 	MediaTypeJSON        = "application/json"
 	MediaTypeOctetStream = "application/octet-stream"

--- a/server/get_header.go
+++ b/server/get_header.go
@@ -89,6 +89,7 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 			req.Header.Set(HeaderKeySlotUID, slotUID.String())
 			req.Header.Set(HeaderStartTimeUnixMS, startTime)
 			req.Header.Set(HeaderUserAgent, userAgent)
+			req.Header.Set(HeaderDateMilliseconds, startTime)
 
 			// Send the request
 			log.Debug("requesting header")

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -79,8 +79,9 @@ func processPayload[P Payload](m *BoostService, log *logrus.Entry, ua UserAgent,
 
 	// Add request headers
 	headers := map[string]string{
-		HeaderKeySlotUID:      currentSlotUID,
-		HeaderStartTimeUnixMS: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
+		HeaderKeySlotUID:       currentSlotUID,
+		HeaderStartTimeUnixMS:  fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
+		HeaderDateMilliseconds: fmt.Sprintf("%d", time.Now().UTC().UnixMilli()),
 	}
 
 	// Prepare for requests


### PR DESCRIPTION
- Introduce new HeaderDateMilliseconds constant in constants.go
- Add HeaderDateMilliseconds to getHeader and processPayload methods
- Mark HeaderStartTimeUnixMS as deprecated with a comment

closes #747 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
