### PR TITLE
Add Hoodi testnet flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ Alternatively, run mev-boost without build step:
 go run . -h
 
 # Run mev-boost
-./mev-boost -goerli -relay-check -relay URL-OF-TRUSTED-RELAY
+./mev-boost -hoodi -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
-Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-goerli`/`-sepolia`/`-holesky`).
+Note that you'll need to set the correct genesis fork version (either manually with `-genesis-fork-version` or a helper flag `-mainnet`/`-sepolia`/`-holesky`/`-hoodi`).
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ See also:
   - [Systemd configuration](#systemd-configuration)
 - [Usage](#usage)
   - [Mainnet](#mainnet)
-  - [Goerli testnet](#goerli-testnet)
   - [Sepolia testnet](#sepolia-testnet)
   - [Holesky testnet](#holesky-testnet)
+  - [Hoodi testnet](#hoodi-testnet)
   - [`test-cli`](#test-cli)
   - [mev-boost cli arguments](#mev-boost-cli-arguments)
 - [API](#api)
@@ -196,14 +196,6 @@ Run MEV-Boost pointed at a mainnet relay:
 ./mev-boost -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
-## Goerli testnet
-
-Run MEV-Boost pointed at a Goerli relay:
-
-```
-./mev-boost -goerli -relay-check -relay URL-OF-TRUSTED-RELAY
-```
-
 ## Sepolia testnet
 
 Run MEV-Boost pointed at a Sepolia relay:
@@ -218,6 +210,14 @@ Run MEV-Boost pointed at a Holesky relay:
 
 ```
 ./mev-boost -holesky -relay-check -relay URL-OF-TRUSTED-RELAY
+```
+
+## Hoodi testnet
+
+Run MEV-Boost pointed at a Hoodi relay:
+
+```
+./mev-boost -hoodi -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
 ## `test-cli`
@@ -238,10 +238,10 @@ Usage of mev-boost:
         shorthand for '-loglevel debug'
   -genesis-fork-version string
         use a custom genesis fork version
-  -goerli
-        use Goerli
   -holesky
         use Holesky
+  -hoodi
+        use Hoodi
   -json
         log in JSON format instead of text
   -log-no-version

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -25,6 +25,7 @@ var flags = []cli.Flag{
 	mainnetFlag,
 	sepoliaFlag,
 	holeskyFlag,
+	hoodiFlag,
 	// relay
 	relaysFlag,
 	deprecatedRelayMonitorFlag,
@@ -113,6 +114,12 @@ var (
 		Name:     "holesky",
 		Sources:  cli.EnvVars("HOLESKY"),
 		Usage:    "use Holesky",
+		Category: GenesisCategory,
+	}
+	hoodiFlag = &cli.BoolFlag{
+		Name:     "hoodi",
+		Sources:  cli.EnvVars("HOODI"),
+		Usage:    "use Hoodi",
 		Category: GenesisCategory,
 	}
 	// Relay

--- a/cli/main.go
+++ b/cli/main.go
@@ -20,13 +20,13 @@ import (
 const (
 	genesisForkVersionMainnet = "0x00000000"
 	genesisForkVersionSepolia = "0x90000069"
-	genesisForkVersionGoerli  = "0x00001020"
 	genesisForkVersionHolesky = "0x01017000"
+	genesisForkVersionHoodi   = "0x10000910"
 
 	genesisTimeMainnet = 1606824023
 	genesisTimeSepolia = 1655733600
-	genesisTimeGoerli  = 1614588812
 	genesisTimeHolesky = 1695902400
+	genesisTimeHoodi   = 1742213400
 )
 
 var (
@@ -143,12 +143,15 @@ func setupGenesis(cmd *cli.Command) (string, uint64) {
 	case cmd.Bool(holeskyFlag.Name):
 		genesisForkVersion = genesisForkVersionHolesky
 		genesisTime = genesisTimeHolesky
+	case cmd.Bool(hoodiFlag.Name):
+		genesisForkVersion = genesisForkVersionHoodi
+		genesisTime = genesisTimeHoodi
 	case cmd.Bool(mainnetFlag.Name):
 		genesisForkVersion = genesisForkVersionMainnet
 		genesisTime = genesisTimeMainnet
 	default:
 		flag.Usage()
-		log.Fatal("please specify a genesis fork version (eg. -mainnet / -sepolia / -goerli / -holesky / -genesis-fork-version flags)")
+		log.Fatal("please specify a genesis fork version (eg. -mainnet / -sepolia / -holesky / -hoodi / -genesis-fork-version flags)")
 	}
 
 	if cmd.IsSet(customGenesisTimeFlag.Name) {

--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -64,7 +64,7 @@ Env & defaults:
 ### Run mev-boost
 
 ```
-./mev-boost -goerli -relay-check -relay URL-OF-TRUSTED-RELAY
+./mev-boost -hoodi -relay-check -relay URL-OF-TRUSTED-RELAY
 ```
 
 ### Run beacon node


### PR DESCRIPTION
## 📝 Summary

This PR adds a Hoodi testnet flag to MEV-Boost.

## 📚 References

* https://github.com/eth-clients/hoodi

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
