### PR TITLE
Update linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,13 +27,13 @@ jobs:
           git diff-index --quiet HEAD
 
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@v0.7.0
+        run: go install mvdan.cc/gofumpt@v0.8.0
 
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
 
       - name: Lint
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,72 +1,76 @@
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     - canonicalheader
+    - contextcheck
+    - copyloopvar
+    - cyclop
     - depguard
     - dupl
     - exhaustruct
+    - funcorder
     - funlen
     - gochecknoglobals
     - gochecknoinits
+    - gocognit
+    - goconst
     - gocritic
     - godot
     - godox
+    - gosec
+    - intrange
+    - ireturn
     - lll
+    - maintidx
     - mnd
     - musttag
     - nlreturn
+    - noctx
     - nonamedreturns
     - paralleltest
-    - testpackage
-    - varnamelen
-    - wrapcheck
-    - wsl
-
-    #
-    # Maybe fix later:
-    #
-    - cyclop
-    - gocognit
-    - goconst
-    - gosec
-    - ireturn
-    - maintidx
-    - noctx
-    - tagliatelle
     - perfsprint
-
-    #
-    # Disabled because of generics:
-    #
-    - contextcheck
     - rowserrcheck
     - sqlclosecheck
+    - tagliatelle
+    - testpackage
+    - varnamelen
     - wastedassign
-
-    #
-    # Disabled because deprecated:
-    #
-    - copyloopvar
-
-    #
-    # Disabled due to versioning:
-    #
-    - intrange
-
-
-linters-settings:
-  gofumpt:
-    extra-rules: true
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-  gomoddirectives:
-    replace-allow-list:
-      - github.com/attestantio/go-builder-client
-      - github.com/attestantio/go-eth2-client
-
-output:
-  print-issued-lines: true
-  sort-results: true
+    - wrapcheck
+    - wsl
+  settings:
+    gomoddirectives:
+      replace-allow-list:
+        - github.com/attestantio/go-builder-client
+        - github.com/attestantio/go-eth2-client
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/server/get_header.go
+++ b/server/get_header.go
@@ -226,11 +226,12 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 			// Compare the bid with already known top bid (if any)
 			if !result.response.IsEmpty() {
 				valueDiff := bidInfo.value.Cmp(result.bidInfo.value)
-				if valueDiff == -1 {
+				switch valueDiff {
+				case -1:
 					// The current bid is less profitable than already known one
 					log.Debug("ignoring less profitable bid")
 					return
-				} else if valueDiff == 0 {
+				case 0:
 					// The current bid is equally profitable as already known one
 					// Use hash as tiebreaker
 					previousBidBlockHash := result.bidInfo.blockHash

--- a/server/mock/mock_relay.go
+++ b/server/mock/mock_relay.go
@@ -172,7 +172,10 @@ func (m *Relay) defaultHandleRegisterValidator(w http.ResponseWriter, req *http.
 		return
 	}
 	req.Body.Close()
-	if reqContentType == "" || reqContentType == "application/json" {
+	switch reqContentType {
+	case "":
+		fallthrough
+	case "application/json":
 		var payload []builderApiV1.SignedValidatorRegistration
 		decoder := json.NewDecoder(bytes.NewReader(regBytes))
 		decoder.DisallowUnknownFields()
@@ -180,13 +183,13 @@ func (m *Relay) defaultHandleRegisterValidator(w http.ResponseWriter, req *http.
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-	} else if reqContentType == "application/octet-stream" {
+	case "application/octet-stream":
 		var validatorRegistrations builderApiV1.SignedValidatorRegistrations
 		if err := validatorRegistrations.UnmarshalSSZ(regBytes); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-	} else {
+	default:
 		panic("invalid content type: " + reqContentType)
 	}
 

--- a/server/service.go
+++ b/server/service.go
@@ -323,13 +323,14 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Respond appropriately
-	if proposerPreferredContentType == MediaTypeJSON {
+	switch proposerPreferredContentType {
+	case MediaTypeJSON:
 		log.Debug("responding with JSON")
 		m.respondGetHeaderJSON(w, &result)
-	} else if proposerPreferredContentType == MediaTypeOctetStream {
+	case MediaTypeOctetStream:
 		log.Debug("responding with SSZ")
 		m.respondGetHeaderSSZ(w, &result)
-	} else {
+	default:
 		message := fmt.Sprintf("unsupported media type: %s", proposerPreferredContentType)
 		log.Error(message)
 		m.respondError(w, http.StatusNotAcceptable, message)
@@ -389,13 +390,14 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 	}
 
 	// Respond appropriately
-	if proposerPreferredContentType == MediaTypeJSON {
+	switch proposerPreferredContentType {
+	case MediaTypeJSON:
 		log.Debug("responding with JSON")
 		m.respondGetPayloadJSON(w, result)
-	} else if proposerPreferredContentType == MediaTypeOctetStream {
+	case MediaTypeOctetStream:
 		log.Debug("responding with SSZ")
 		m.respondGetPayloadSSZ(w, result)
-	} else {
+	default:
 		message := fmt.Sprintf("unsupported media type: %s", proposerPreferredContentType)
 		log.Error(message)
 		m.respondError(w, http.StatusNotAcceptable, message)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -347,7 +347,7 @@ func TestGetHeader(t *testing.T) {
 		bid := new(builderApiDeneb.SignedBuilderBid)
 		err := bid.UnmarshalSSZ(rr.Body.Bytes())
 		require.NoError(t, err)
-		require.EqualValues(t, *resp.Deneb, *bid)
+		require.Equal(t, *resp.Deneb, *bid)
 	})
 
 	t.Run("Relay returns SSZ, mev-boost returns SSZ", func(t *testing.T) {


### PR DESCRIPTION
## 📝 Summary

This PR updates `gofumpt` and `golangci-lint` (there's a v2 version now!) and fixes their new findings.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
