### PR TITLE
Fix parsing of custom genesis time

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -155,7 +155,7 @@ func setupGenesis(cmd *cli.Command) (string, uint64) {
 	}
 
 	if cmd.IsSet(customGenesisTimeFlag.Name) {
-		genesisTime = cmd.Uint64(customGenesisTimeFlag.Name)
+		genesisTime = uint64(cmd.Uint(customGenesisTimeFlag.Name))
 	}
 	log.Infof("using genesis fork version: %s time: %d", genesisForkVersion, genesisTime)
 	return genesisForkVersion, genesisTime


### PR DESCRIPTION
## 📝 Summary

I made an incorrect change when updating `urfave/cli` here:
* #771

Apparently, `cmd.Uint64` thinks the value isn't found and returns 0.

Note that this fix is not urgent. It only affects logs when testing with a devnet. Eg this:

https://github.com/flashbots/mev-boost/blob/ee0c91c42fc0d49254498e4d016159fb828c8d8c/server/get_payload.go#L100-L106

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
