### PR TITLE
Send getPayload request to all relays again

### DIFF
--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -152,7 +152,7 @@ func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockByt
 				log.WithField("relaySupportsSSZ", relaySupportsSSZ).Debug("encoding preference")
 
 				// If the relay provided the bid in JSON or did not provide a bid for this payload,
-				// we must convert the signed blinded beacon block to SSZ for this relay
+				// we must convert the signed blinded beacon block from SSZ to JSON for this relay
 				if parsedProposerContentType == MediaTypeOctetStream && !relaySupportsSSZ {
 					requestContentType = MediaTypeJSON
 					startTime := time.Now()

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -128,28 +129,7 @@ func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockByt
 	requestCtx, requestCtxCancel := context.WithTimeout(context.Background(), m.httpClientGetPayload.Timeout)
 	defer requestCtxCancel()
 
-	// Make a list of relays without SSZ support
-	var relaysWithoutSSZ []string
-	for _, relay := range originalBid.relays {
-		if !relay.SupportsSSZ {
-			relaysWithoutSSZ = append(relaysWithoutSSZ, relay.URL.Hostname())
-		}
-	}
-
-	// Convert the blinded block to JSON if there's a relay that doesn't support SSZ yet
-	var signedBlindedBeaconBlockBytesJSON []byte
-	if proposerContentType == MediaTypeOctetStream && len(relaysWithoutSSZ) > 0 {
-		log.WithField("relaysWithoutSSZ", relaysWithoutSSZ).Info("Converting request from SSZ to JSON for relay(s)")
-		signedBlindedBeaconBlockBytesJSON, err = convertSSZToJSON(proposerEthConsensusVersion, signedBlindedBeaconBlockBytes)
-		if err != nil {
-			log.WithError(errFailedToConvert).Error("failed to convert SSZ to JSON")
-			return nil, bidResp{}
-		}
-	}
-
-	// Only request payloads from relays which provided the bid. This is
-	// necessary now because we use the bid to track relay encoding preferences.
-	for _, relay := range originalBid.relays {
+	for _, relay := range m.relays {
 		go func(relay types.RelayEntry) {
 			url := relay.GetURI(params.PathGetPayload)
 			log := log.WithField("url", url)
@@ -157,12 +137,34 @@ func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockByt
 
 			// If the request fails, try again a few times with 100ms between tries
 			resp, err := retry(requestCtx, m.requestMaxRetries, 100*time.Millisecond, func() (*http.Response, error) {
-				// If necessary, use the JSON encoded version and the JSON Content-Type header
+				// Default to the content from the proposer
 				requestContentType := parsedProposerContentType
 				requestBytes := signedBlindedBeaconBlockBytes
-				if parsedProposerContentType == MediaTypeOctetStream && !relay.SupportsSSZ {
-					requestBytes = signedBlindedBeaconBlockBytesJSON
+
+				// Check if the relay supports SSZ
+				relaySupportsSSZ := false
+				for _, originalBidRelay := range originalBid.relays {
+					if relay.URL == originalBidRelay.URL {
+						relaySupportsSSZ = originalBidRelay.SupportsSSZ
+						break
+					}
+				}
+				log.WithField("relaySupportsSSZ", relaySupportsSSZ).Debug("encoding preference")
+
+				// If the relay provided the bid in JSON or did not provide a bid for this payload,
+				// we must convert the signed blinded beacon block to SSZ for this relay
+				if parsedProposerContentType == MediaTypeOctetStream && !relaySupportsSSZ {
 					requestContentType = MediaTypeJSON
+					startTime := time.Now()
+					requestBytes, err = convertSSZToJSON(proposerEthConsensusVersion, signedBlindedBeaconBlockBytes)
+					if err != nil {
+						log.WithError(errFailedToConvert).Error("failed to convert SSZ to JSON")
+						return nil, err
+					}
+					log.WithFields(logrus.Fields{
+						"relayProvidedBid": slices.Contains(originalBid.relays, relay),
+						"conversionTime":   time.Since(startTime),
+					}).Info("Converted request from SSZ to JSON for relay")
 				}
 
 				// Make a new request

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -988,14 +989,20 @@ func TestGetPayload(t *testing.T) {
 		bid.relays[0].SupportsSSZ = true
 		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
 
+		// Make a wait group to ensure both relays get the request
+		var wg sync.WaitGroup
+		wg.Add(len(backend.relays))
+
 		// Ensure the first relay gets the request in SSZ
 		backend.relays[0].OverrideHandleGetPayload(func(w http.ResponseWriter, req *http.Request) {
+			defer wg.Done()
 			require.Equal(t, MediaTypeOctetStream, req.Header.Get(HeaderContentType)) //nolint:testifylint
 			backend.relays[0].DefaultHandleGetPayload(w, req)
 		})
 
 		// Ensure the second relay gets the request in JSON
 		backend.relays[1].OverrideHandleGetPayload(func(w http.ResponseWriter, req *http.Request) {
+			defer wg.Done()
 			require.Equal(t, MediaTypeJSON, req.Header.Get(HeaderContentType)) //nolint:testifylint
 			backend.relays[1].DefaultHandleGetPayload(w, req)
 		})
@@ -1007,6 +1014,7 @@ func TestGetPayload(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 		// Ensure both relays got the request
+		wg.Wait()
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 		require.Equal(t, 1, backend.relays[1].GetRequestCount(path))
 	})

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -973,6 +973,44 @@ func TestGetPayload(t *testing.T) {
 		require.Equal(t, MediaTypeOctetStream, rr.Header().Get(HeaderContentType))
 	})
 
+	t.Run("A relay which does not provide the bid gets a JSON request", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set("Eth-Consensus-Version", "deneb")
+		header.Set("Accept", "application/octet-stream")
+		header.Set("Content-Type", "application/octet-stream")
+
+		// Setup backend with 2 relays
+		backend := newTestBackend(t, 2, time.Second)
+
+		// Add the bid to the service
+		bid := bidResp{relays: make([]types.RelayEntry, 1)}
+		bid.relays[0] = backend.relays[0].RelayEntry
+		bid.relays[0].SupportsSSZ = true
+		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
+
+		// Ensure the first relay gets the request in SSZ
+		backend.relays[0].OverrideHandleGetPayload(func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, MediaTypeOctetStream, req.Header.Get(HeaderContentType)) //nolint:testifylint
+			backend.relays[0].DefaultHandleGetPayload(w, req)
+		})
+
+		// Ensure the second relay gets the request in JSON
+		backend.relays[1].OverrideHandleGetPayload(func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, MediaTypeJSON, req.Header.Get(HeaderContentType)) //nolint:testifylint
+			backend.relays[1].DefaultHandleGetPayload(w, req)
+		})
+
+		// Send the request
+		payloadBytes, err := payload.MarshalSSZ()
+		require.NoError(t, err)
+		rr := backend.requestBytes(t, http.MethodPost, path, header, payloadBytes)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+		// Ensure both relays got the request
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
+		require.Equal(t, 1, backend.relays[1].GetRequestCount(path))
+	})
+
 	t.Run("Bad response from relays", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)


### PR DESCRIPTION
## 📝 Summary

Instead of only sending the getPayload request to relays which provided this bid, send the getPayload request to all relays and convert the signed blinded beacon block to JSON if necessary.

## ⛱ Motivation and Context

In theory, this should improve liveness. If, for example, there is a relay which is geographically closer to the proposer, it might get the getPayload request sooner and therefore it would distribute the block faster.

## 📚 References

https://discord.com/channels/595666850260713488/1341434255154348034/1367203484620947508

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
