### PR TITLE
Docker image now runs as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.24 as builder
+FROM golang:1.24 AS builder
 ARG VERSION
 WORKDIR /build
 
@@ -8,16 +8,18 @@ COPY go.sum ./
 
 RUN go mod download
 
-ADD . .
+COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
     -v \
     -ldflags "-w -s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" \
     -o mev-boost .
 
-FROM alpine
+FROM alpine:3
 WORKDIR /app
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/mev-boost /app/mev-boost
 EXPOSE 18550
+RUN adduser -D mev
+USER mev
 ENTRYPOINT ["/app/mev-boost"]


### PR DESCRIPTION
## 📝 Summary

Docker image now runs as non-root.

## ⛱ Motivation and Context

It's generally a good idea to restrict the running user as it minimizes the risk of container escapes.

## 📚 References

-

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
