### PR TITLE
Update default gas limit as per the latest recommendations

### DIFF
--- a/cmd/test-cli/README.md
+++ b/cmd/test-cli/README.md
@@ -20,7 +20,7 @@ getPayload [-vd-file] [-mev-boost] [-bn] [-en] [-mm] [-bellatrix-fork-version] [
 
 Env & defaults:
 	[generate]
-	-gas-limit                               = 30000000
+	-gas-limit                               = 45000000
 	-fee-recipient  VALIDATOR_FEE_RECIPIENT  = 0x0000000000000000000000000000000000000000
 
 	[register]

--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -181,7 +181,7 @@ func main() {
 	getPayloadCommand.StringVar(&bellatrixForkVersionStr, "bellatrix-fork-version", envBellatrixForkVersion, "hex encoded bellatrix fork version")
 
 	var gasLimit uint64
-	envGasLimitStr := getEnv("VALIDATOR_GAS_LIMIT", "30000000")
+	envGasLimitStr := getEnv("VALIDATOR_GAS_LIMIT", "45000000")
 	envGasLimit, err := strconv.ParseUint(envGasLimitStr, 10, 64)
 	if err != nil {
 		log.WithError(err).Fatal("invalid gas limit specified")


### PR DESCRIPTION
## 📝 Summary

The gas limit recommendation has been updated twice in the last weeks, and this PR is to mirror those updates. A writeup on the testing approach can be found here: https://ethpandaops.io/posts/gaslimit-scaling/

## ⛱ Motivation and Context

We are noticing a lot of validators still signaling 30M on mainnet, this however is contrary to what we hear when speaking to them. We are looking into the datasets to ensure we're gathering the right data, but mev-boost could explain some of the discrepancy. It is possible that when using all defaults, the node is falling back to the default used by mev-boost, this theory is still pending testing - but still worth addressing irrespective of the outcome. 


## ✅ I have run these commands

* [  ] `make lint` (linter already fails from untouched code btw)
* [ x ] `make test-race` 
* [ x ] `go mod tidy`
