### PR TITLE
add support for v2 blinded blocks

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -10,6 +10,16 @@ import (
 
 const (
 	SlotTimeSecMainnet = 12
+	// FieldElementsPerBlob is the number of field elements needed to represent a blob.
+	FieldElementsPerBlob = 4096
+	// BlobExpansionFactor is the factor by which we extend a blob for PeerDas.
+	BlobExpansionFactor = 2
+	// FieldElementsPerCell is the number of field elements in a cell
+	FieldElementsPerCell = 64
+	// FieldElementsPerExtBlob is the number of field elements needed to represent an extended blob.
+	FieldElementsPerExtBlob = FieldElementsPerBlob * BlobExpansionFactor
+	// CellsPerExtBlob is the number of cells in an extended blob.
+	CellsPerExtBlob = FieldElementsPerExtBlob / FieldElementsPerCell
 )
 
 func GetEnv(key, defaultValue string) string {

--- a/common/common.go
+++ b/common/common.go
@@ -12,9 +12,9 @@ const (
 	SlotTimeSecMainnet = 12
 	// FieldElementsPerBlob is the number of field elements needed to represent a blob.
 	FieldElementsPerBlob = 4096
-	// BlobExpansionFactor is the factor by which we extend a blob for PeerDas.
+	// BlobExpansionFactor is the factor by which we extend a blob for PeerDAS.
 	BlobExpansionFactor = 2
-	// FieldElementsPerCell is the number of field elements in a cell
+	// FieldElementsPerCell is the number of field elements in a cell.
 	FieldElementsPerCell = 64
 	// FieldElementsPerExtBlob is the number of field elements needed to represent an extended blob.
 	FieldElementsPerExtBlob = FieldElementsPerBlob * BlobExpansionFactor

--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/attestantio/go-eth2-client => github.com/jtraglia/go-eth2-client v0.21.5-0.20250410190628-e845cec4674f
+
+replace github.com/attestantio/go-builder-client => github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 
 require (
 	github.com/attestantio/go-builder-client v0.6.1
-	github.com/attestantio/go-eth2-client v0.25.0
+	github.com/attestantio/go-eth2-client v0.25.1-0.20250603135601-6ac0bfda7fda
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/ferranbt/fastssz v0.1.4 // indirect
@@ -60,7 +60,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/attestantio/go-eth2-client => github.com/jtraglia/go-eth2-client v0.21.5-0.20250410211702-92a5240d75c6
 
 replace github.com/attestantio/go-builder-client => github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546

--- a/go.mod
+++ b/go.mod
@@ -20,10 +20,10 @@ require (
 	github.com/bits-and-blooms/bitset v1.22.0 // indirect
 	github.com/consensys/bavard v0.1.30 // indirect
 	github.com/consensys/gnark-crypto v0.17.0 // indirect
+	github.com/crate-crypto/go-eth-kzg v1.3.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
-	github.com/crate-crypto/go-kzg-4844 v1.1.0 // indirect
 	github.com/emicklei/dot v1.8.0 // indirect
-	github.com/ethereum/c-kzg-4844 v1.0.3 // indirect
+	github.com/ethereum/c-kzg-4844/v2 v2.0.1 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
 	github.com/goccy/go-yaml v1.17.1 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
@@ -62,3 +62,4 @@ require (
 )
 
 replace github.com/attestantio/go-builder-client => github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546
+replace github.com/ethereum/go-ethereum => github.com/MariusVanDerWijden/go-ethereum v0.0.0-20250401090816-5ab5127f5408

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/attestantio/go-eth2-client => github.com/jtraglia/go-eth2-client v0.21.5-0.20250410190628-e845cec4674f
+replace github.com/attestantio/go-eth2-client => github.com/jtraglia/go-eth2-client v0.21.5-0.20250410211702-92a5240d75c6
 
 replace github.com/attestantio/go-builder-client => github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/huandu/go-clone/generic v1.6.0 h1:Wgmt/fUZ28r16F2Y3APotFD59sHk1p78K0X
 github.com/huandu/go-clone/generic v1.6.0/go.mod h1:xgd9ZebcMsBWWcBx5mVMCoqMX24gLWr5lQicr+nVXNs=
 github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546 h1:UnMUnbUz6fiJ1Ox7hNMkAS6T+Vcdy2qjo9q2D3q8zqg=
 github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546/go.mod h1:3Z2KfjbuX2EmJajEmDb3I/JdDqzlm4WsojnCugO0oM0=
-github.com/jtraglia/go-eth2-client v0.21.5-0.20250410190628-e845cec4674f h1:XacizBmPNKeJK/MdsbEUC/U6LVUlsuPsvgC8ia8QPBI=
-github.com/jtraglia/go-eth2-client v0.21.5-0.20250410190628-e845cec4674f/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
+github.com/jtraglia/go-eth2-client v0.21.5-0.20250410211702-92a5240d75c6 h1:+rkagNgm3jRqhHxy1JA+PwhB5Jk+pJt9esk7C3l/Tvg=
+github.com/jtraglia/go-eth2-client v0.21.5-0.20250410211702-92a5240d75c6/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
+github.com/attestantio/go-eth2-client v0.25.1-0.20250603135601-6ac0bfda7fda h1:Wc7YGICtTWKNZvMjpIN/l6HKTj9POEU9N67NIWWWOk0=
+github.com/attestantio/go-eth2-client v0.25.1-0.20250603135601-6ac0bfda7fda/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -57,8 +59,6 @@ github.com/huandu/go-clone/generic v1.6.0 h1:Wgmt/fUZ28r16F2Y3APotFD59sHk1p78K0X
 github.com/huandu/go-clone/generic v1.6.0/go.mod h1:xgd9ZebcMsBWWcBx5mVMCoqMX24gLWr5lQicr+nVXNs=
 github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546 h1:UnMUnbUz6fiJ1Ox7hNMkAS6T+Vcdy2qjo9q2D3q8zqg=
 github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546/go.mod h1:3Z2KfjbuX2EmJajEmDb3I/JdDqzlm4WsojnCugO0oM0=
-github.com/jtraglia/go-eth2-client v0.21.5-0.20250410211702-92a5240d75c6 h1:+rkagNgm3jRqhHxy1JA+PwhB5Jk+pJt9esk7C3l/Tvg=
-github.com/jtraglia/go-eth2-client v0.21.5-0.20250410211702-92a5240d75c6/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MariusVanDerWijden/go-ethereum v0.0.0-20250401090816-5ab5127f5408 h1:0H1RpU0pilwhz2sItGYkA1z8+i4MJSf0u/kH5vQloTk=
+github.com/MariusVanDerWijden/go-ethereum v0.0.0-20250401090816-5ab5127f5408/go.mod h1:huOmsndLTH6QOh8JLawPM5qPrQbdQ5QlD2wd5AN9VTI=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/attestantio/go-eth2-client v0.25.1-0.20250603135601-6ac0bfda7fda h1:Wc7YGICtTWKNZvMjpIN/l6HKTj9POEU9N67NIWWWOk0=
@@ -10,6 +12,8 @@ github.com/consensys/bavard v0.1.30 h1:wwAj9lSnMLFXjEclKwyhf7Oslg8EoaFz9u1QGgt0b
 github.com/consensys/bavard v0.1.30/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/consensys/gnark-crypto v0.17.0 h1:vKDhZMOrySbpZDCvGMOELrHFv/A9mJ7+9I8HEfRZSkI=
 github.com/consensys/gnark-crypto v0.17.0/go.mod h1:A2URlMHUT81ifJ0UlLzSlm7TmnE3t7VxEThApdMukJw=
+github.com/crate-crypto/go-eth-kzg v1.3.0 h1:05GrhASN9kDAidaFJOda6A4BEvgvuXbazXg/0E3OOdI=
+github.com/crate-crypto/go-eth-kzg v1.3.0/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
 github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a h1:W8mUrRp6NOVl3J+MYp5kPMoUZPp7aOYHtaua31lwRHg=
 github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a/go.mod h1:sTwzHBvIzm2RfVCGNEBZgRyjwK40bVoun3ZnGOCafNM=
 github.com/crate-crypto/go-kzg-4844 v1.1.0 h1:EN/u9k2TF6OWSHrCCDBBU6GLNMq88OspHHlMnHfoyU4=
@@ -23,10 +27,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/emicklei/dot v1.8.0 h1:HnD60yAKFAevNeT+TPYr9pb8VB9bqdeSo0nzwIW6IOI=
 github.com/emicklei/dot v1.8.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
-github.com/ethereum/c-kzg-4844 v1.0.3 h1:IEnbOHwjixW2cTvKRUlAAUOeleV7nNM/umJR+qy4WDs=
-github.com/ethereum/c-kzg-4844 v1.0.3/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
-github.com/ethereum/go-ethereum v1.15.9 h1:bRra1zi+/q+qyXZ6fylZOrlaF8kDdnlTtzNTmNHfX+g=
-github.com/ethereum/go-ethereum v1.15.9/go.mod h1:+S9k+jFzlyVTNcYGvqFhzN/SFhI6vA+aOY4T5tLSPL0=
+github.com/ethereum/c-kzg-4844/v2 v2.0.1 h1:NuErvd0Ha5gLvvZ1m9Id9UZ11kcqMBUUXsbm7yXcAYI=
+github.com/ethereum/c-kzg-4844/v2 v2.0.1/go.mod h1:urP+cLBtKCW4BS5bnA2IXYs1PRGPpXmdotqpBuU6/5s=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/ferranbt/fastssz v0.1.4 h1:OCDB+dYDEQDvAgtAGnTSidK1Pe2tW3nFV40XyMkTeDY=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
-github.com/attestantio/go-builder-client v0.6.1 h1:fn6PC8aDWx2YbptstR1JKP8NyakiNJJTiOE5f9N0z5Q=
-github.com/attestantio/go-builder-client v0.6.1/go.mod h1:f8wi3HzuPxfJoi2PirpJK3yZhte4SavDgKJbRrKoB1Q=
-github.com/attestantio/go-eth2-client v0.25.0 h1:wLQxoteGCbTE/vKCMASx1ze+Zm9rcqtltRnblaLJup4=
-github.com/attestantio/go-eth2-client v0.25.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -59,6 +55,10 @@ github.com/huandu/go-clone v1.7.2 h1:3+Aq0Ed8XK+zKkLjE2dfHg0XrpIfcohBE1K+c8Usxoo
 github.com/huandu/go-clone v1.7.2/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/go-clone/generic v1.6.0 h1:Wgmt/fUZ28r16F2Y3APotFD59sHk1p78K0XLdbUYN5U=
 github.com/huandu/go-clone/generic v1.6.0/go.mod h1:xgd9ZebcMsBWWcBx5mVMCoqMX24gLWr5lQicr+nVXNs=
+github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546 h1:UnMUnbUz6fiJ1Ox7hNMkAS6T+Vcdy2qjo9q2D3q8zqg=
+github.com/jtraglia/go-builder-client v0.4.6-0.20250410195459-42a3ff7f1546/go.mod h1:3Z2KfjbuX2EmJajEmDb3I/JdDqzlm4WsojnCugO0oM0=
+github.com/jtraglia/go-eth2-client v0.21.5-0.20250410190628-e845cec4674f h1:XacizBmPNKeJK/MdsbEUC/U6LVUlsuPsvgC8ia8QPBI=
+github.com/jtraglia/go-eth2-client v0.21.5-0.20250410190628-e845cec4674f/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/server/constants.go
+++ b/server/constants.go
@@ -17,4 +17,5 @@ const (
 	EthConsensusVersionCapella   = "capella"
 	EthConsensusVersionDeneb     = "deneb"
 	EthConsensusVersionElectra   = "electra"
+	EthConsensusVersionFulu      = "fulu"
 )

--- a/server/get_header.go
+++ b/server/get_header.go
@@ -279,6 +279,10 @@ func decodeBid(respBytes []byte, respContentType, ethConsensusVersion string, bi
 				bid.Version = spec.DataVersionElectra
 				bid.Electra = new(builderApiElectra.SignedBuilderBid)
 				return bid.Electra.UnmarshalSSZ(respBytes)
+			case EthConsensusVersionFulu:
+				bid.Version = spec.DataVersionFulu
+				bid.Fulu = new(builderApiElectra.SignedBuilderBid)
+				return bid.Fulu.UnmarshalSSZ(respBytes)
 			default:
 				return errInvalidForkVersion
 			}
@@ -322,6 +326,9 @@ func (m *BoostService) respondGetHeaderSSZ(w http.ResponseWriter, result *bidRes
 	case spec.DataVersionElectra:
 		w.Header().Set(HeaderEthConsensusVersion, EthConsensusVersionElectra)
 		sszData, err = result.response.Electra.MarshalSSZ()
+	case spec.DataVersionFulu:
+		w.Header().Set(HeaderEthConsensusVersion, EthConsensusVersionFulu)
+		sszData, err = result.response.Fulu.MarshalSSZ()
 	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair:
 		err = errInvalidForkVersion
 	}

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -350,7 +350,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 		log.WithFields(logrus.Fields{
 			"requestBlobCommitments": len(requestCommitments),
 			"responseCommitments":    len(responseCommitments),
-		}).Error("different lengths for commitments")
+		}).Error("wrong lengths for commitments")
 		return errInvalidKZGLength
 	}
 	for i, commitment := range requestCommitments {
@@ -377,7 +377,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 				"requestBlobCommitments": len(requestCommitments),
 				"responseProofs":         len(responseProofs),
 				"cellsPerExtBlob":        common.CellsPerExtBlob,
-			}).Error("different lengths for proofs")
+			}).Error("wrong lengths for proofs")
 			return errInvalidKZGLength
 		}
 	} else {
@@ -385,7 +385,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 			log.WithFields(logrus.Fields{
 				"requestBlobCommitments": len(requestCommitments),
 				"responseProofs":         len(responseProofs),
-			}).Error("different lengths for proofs")
+			}).Error("wrong lengths for proofs")
 			return errInvalidKZGLength
 		}
 	}
@@ -400,7 +400,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 		log.WithFields(logrus.Fields{
 			"requestBlobCommitments": len(requestCommitments),
 			"responseBlobs":          len(responseBlobs),
-		}).Error("different lengths for blobs")
+		}).Error("wrong lengths for blobs")
 		return errInvalidKZGLength
 	}
 

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -45,6 +45,7 @@ var (
 // Core Logic
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Depreciated: For reference: https://github.com/ethereum/builder-specs/issues/119
 // getPayload requests the payload (execution payload, blobs bundle, etc) from the relays
 func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (*builderApi.VersionedSubmitBlindedBlockResponse, bidResp) {
 	// Get the request's content type

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -45,7 +45,7 @@ var (
 // Core Logic
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Depreciated: For reference: https://github.com/ethereum/builder-specs/issues/119
+// Deprecated: For reference: https://github.com/ethereum/builder-specs/issues/119
 // getPayload requests the payload (execution payload, blobs bundle, etc) from the relays
 func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (*builderApi.VersionedSubmitBlindedBlockResponse, bidResp) {
 	// Get the request's content type

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -25,6 +25,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/flashbots/mev-boost/common"
 	"github.com/flashbots/mev-boost/config"
 	"github.com/flashbots/mev-boost/server/params"
 	"github.com/flashbots/mev-boost/server/types"
@@ -338,7 +339,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 		log.WithError(err).Error("failed to get response blobs bundle")
 		return err
 	}
-
+	
 	// Check commitments
 	responseCommitments, err := responseBlobsBundle.Commitments()
 	if err != nil {
@@ -369,12 +370,24 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 		log.WithError(err).Error("failed to get response proofs")
 		return err
 	}
-	if len(requestCommitments) != len(responseProofs) {
-		log.WithFields(logrus.Fields{
-			"requestBlobCommitments": len(requestCommitments),
-			"responseProofs":         len(responseProofs),
-		}).Error("different lengths for proofs")
-		return errInvalidKZGLength
+
+	if request.Version >= spec.DataVersionFulu {
+		if len(requestCommitments) * common.CellsPerExtBlob != len(responseProofs) {
+			log.WithFields(logrus.Fields{
+				"requestBlobCommitments": len(requestCommitments),
+				"responseProofs":         len(responseProofs),
+				"cellsPerExtBlob":        common.CellsPerExtBlob,
+			}).Error("different lengths for proofs")
+			return errInvalidKZGLength
+		}
+	} else {
+		if len(requestCommitments) != len(responseProofs) {
+			log.WithFields(logrus.Fields{
+				"requestBlobCommitments": len(requestCommitments),
+				"responseProofs":         len(responseProofs),
+			}).Error("different lengths for proofs")
+			return errInvalidKZGLength
+		}
 	}
 
 	// Check blobs

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -364,13 +364,13 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 	// Check proofs
 	responseProofs, err := responseBlobsBundle.Proofs()
 	if err != nil {
-		log.WithError(err).Error("failed to get response blobs")
+		log.WithError(err).Error("failed to get response proofs")
 		return err
 	}
 	if len(requestCommitments) != len(responseProofs) {
 		log.WithFields(logrus.Fields{
 			"requestBlobCommitments": len(requestCommitments),
-			"responseProofss":        len(responseProofs),
+			"responseProofs":         len(responseProofs),
 		}).Error("different lengths for proofs")
 		return errInvalidKZGLength
 	}
@@ -467,44 +467,44 @@ func decodeSignedBlindedBeaconBlock(in []byte, contentType, ethConsensusVersion 
 		var err error
 		switch ethConsensusVersion {
 		case EthConsensusVersionBellatrix:
-			bellatrixBlock := new(eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
-			err = json.Unmarshal(in, bellatrixBlock)
-			if err == nil {
-				out.Version = spec.DataVersionBellatrix
-				out.Bellatrix = bellatrixBlock
+			block := new(eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
+			if err = json.Unmarshal(in, block); err != nil {
+				return err
 			}
+			out.Version = spec.DataVersionBellatrix
+			out.Bellatrix = block
 		case EthConsensusVersionCapella:
-			capellaBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
-			err = json.Unmarshal(in, capellaBlock)
-			if err == nil {
-				out.Version = spec.DataVersionCapella
-				out.Capella = capellaBlock
+			block := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
+			if err = json.Unmarshal(in, block); err != nil {
+				return err
 			}
+			out.Version = spec.DataVersionCapella
+			out.Capella = block
 		case EthConsensusVersionDeneb:
-			denebBlock := new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
-			err = json.Unmarshal(in, denebBlock)
-			if err == nil {
-				out.Version = spec.DataVersionDeneb
-				out.Deneb = denebBlock
+			block := new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
+			if err = json.Unmarshal(in, block); err != nil {
+				return err
 			}
+			out.Version = spec.DataVersionDeneb
+			out.Deneb = block
 		case EthConsensusVersionElectra:
-			electraBlock := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
-			err = json.Unmarshal(in, electraBlock)
-			if err == nil {
-				out.Version = spec.DataVersionElectra
-				out.Electra = electraBlock
+			block := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+			if err = json.Unmarshal(in, block); err != nil {
+				return err
 			}
+			out.Version = spec.DataVersionElectra
+			out.Electra = block
 		case EthConsensusVersionFulu:
-			fuluBlock := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
-			err = json.Unmarshal(in, fuluBlock)
-			if err == nil {
-				out.Version = spec.DataVersionFulu
-				out.Fulu = fuluBlock
+			block := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+			if err = json.Unmarshal(in, block); err != nil {
+				return err
 			}
+			out.Version = spec.DataVersionFulu
+			out.Fulu = block
 		default:
 			return errInvalidForkVersion
 		}
-		return err
+		return nil
 	}
 	return types.ErrInvalidContentType
 }

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -14,6 +14,7 @@ import (
 
 	builderApi "github.com/attestantio/go-builder-client/api"
 	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiFulu "github.com/attestantio/go-builder-client/api/fulu"
 	eth2Api "github.com/attestantio/go-eth2-client/api"
 	eth2ApiV1Bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
 	eth2ApiV1Capella "github.com/attestantio/go-eth2-client/api/v1/capella"
@@ -35,7 +36,6 @@ var (
 	errInvalidBlockhash = errors.New("invalid blockhash")
 	errInvalidKZGLength = errors.New("invalid KZG commitments length")
 	errInvalidKZG       = errors.New("invalid KZG commitment")
-	errFailedToDecode   = errors.New("failed to decode payload")
 	errFailedToConvert  = errors.New("failed to convert block from SSZ to JSON")
 )
 
@@ -337,29 +337,56 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 		return err
 	}
 
-	// Ensure the blobs bundle field counts are correct
-	if len(requestCommitments) != len(responseBlobsBundle.Blobs) ||
-		len(requestCommitments) != len(responseBlobsBundle.Commitments) ||
-		len(requestCommitments) != len(responseBlobsBundle.Proofs) {
+	// Check commitments
+	responseCommitments, err := responseBlobsBundle.Commitments()
+	if err != nil {
+		log.WithError(err).Error("failed to get response commitments")
+		return err
+	}
+	if len(requestCommitments) != len(responseCommitments) {
 		log.WithFields(logrus.Fields{
-			"requestBlobCommitments":  len(requestCommitments),
-			"responseBlobs":           len(responseBlobsBundle.Blobs),
-			"responseBlobCommitments": len(responseBlobsBundle.Commitments),
-			"responseBlobProofs":      len(responseBlobsBundle.Proofs),
-		}).Error("different lengths for blobs/commitments/proofs")
+			"requestBlobCommitments": len(requestCommitments),
+			"responseCommitments":    len(responseCommitments),
+		}).Error("different lengths for commitments")
 		return errInvalidKZGLength
 	}
-
-	// Ensure the request and response KZG commitments are the same
 	for i, commitment := range requestCommitments {
-		if commitment != responseBlobsBundle.Commitments[i] {
+		if commitment != responseCommitments[i] {
 			log.WithFields(logrus.Fields{
 				"index":                  i,
 				"requestBlobCommitment":  commitment.String(),
-				"responseBlobCommitment": responseBlobsBundle.Commitments[i].String(),
+				"responseBlobCommitment": responseCommitments[i].String(),
 			}).Error("requestBlobCommitment does not equal responseBlobCommitment")
 			return errInvalidKZG
 		}
+	}
+
+	// Check proofs
+	responseProofs, err := responseBlobsBundle.Proofs()
+	if err != nil {
+		log.WithError(err).Error("failed to get response blobs")
+		return err
+	}
+	if len(requestCommitments) != len(responseProofs) {
+		log.WithFields(logrus.Fields{
+			"requestBlobCommitments": len(requestCommitments),
+			"responseProofss":        len(responseProofs),
+		}).Error("different lengths for proofs")
+		return errInvalidKZGLength
+	}
+
+	// Check blobs
+	responseBlobs, err := responseBlobsBundle.Blobs()
+	if err != nil {
+		log.WithError(err).Error("failed to get response blobs")
+		return err
+	}
+	if len(requestCommitments) != len(responseBlobs) {
+		log.WithFields(logrus.Fields{
+			"requestBlobCommitments": len(requestCommitments),
+			"responseBlobs":          len(responseBlobs),
+		}).Error("different lengths for blobs")
+		return errInvalidKZGLength
 	}
 
 	return nil
@@ -386,6 +413,8 @@ func convertSSZToJSON(ethConsensusVersion string, sszBytes []byte) ([]byte, erro
 		block = new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
 	case EthConsensusVersionElectra:
 		block = new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+	case EthConsensusVersionFulu:
+		block = new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
 	default:
 		return nil, errInvalidForkVersion
 	}
@@ -404,61 +433,78 @@ func convertSSZToJSON(ethConsensusVersion string, sszBytes []byte) ([]byte, erro
 func decodeSignedBlindedBeaconBlock(in []byte, contentType, ethConsensusVersion string, out *eth2Api.VersionedSignedBlindedBeaconBlock) error {
 	switch contentType {
 	case MediaTypeOctetStream:
-		if ethConsensusVersion != "" {
-			switch ethConsensusVersion {
-			case EthConsensusVersionBellatrix:
-				out.Version = spec.DataVersionBellatrix
-				out.Bellatrix = new(eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
-				return out.Bellatrix.UnmarshalSSZ(in)
-			case EthConsensusVersionCapella:
-				out.Version = spec.DataVersionCapella
-				out.Capella = new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
-				return out.Capella.UnmarshalSSZ(in)
-			case EthConsensusVersionDeneb:
-				out.Version = spec.DataVersionDeneb
-				out.Deneb = new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
-				return out.Deneb.UnmarshalSSZ(in)
-			case EthConsensusVersionElectra:
-				out.Version = spec.DataVersionElectra
-				out.Electra = new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
-				return out.Electra.UnmarshalSSZ(in)
-			default:
-				return errInvalidForkVersion
-			}
-		} else {
+		if ethConsensusVersion == "" {
 			return types.ErrMissingEthConsensusVersion
 		}
-	case MediaTypeJSON:
-		var err error
-		electraBlock := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
-		err = json.Unmarshal(in, electraBlock)
-		if err == nil {
-			out.Version = spec.DataVersionElectra
-			out.Electra = electraBlock
-			return nil
-		}
-		denebBlock := new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
-		err = json.Unmarshal(in, denebBlock)
-		if err == nil {
-			out.Version = spec.DataVersionDeneb
-			out.Deneb = denebBlock
-			return nil
-		}
-		capellaBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
-		err = json.Unmarshal(in, capellaBlock)
-		if err == nil {
-			out.Version = spec.DataVersionCapella
-			out.Capella = capellaBlock
-			return nil
-		}
-		bellatrixBlock := new(eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
-		err = json.Unmarshal(in, bellatrixBlock)
-		if err == nil {
+		switch ethConsensusVersion {
+		case EthConsensusVersionBellatrix:
 			out.Version = spec.DataVersionBellatrix
-			out.Bellatrix = bellatrixBlock
-			return nil
+			out.Bellatrix = new(eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
+			return out.Bellatrix.UnmarshalSSZ(in)
+		case EthConsensusVersionCapella:
+			out.Version = spec.DataVersionCapella
+			out.Capella = new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
+			return out.Capella.UnmarshalSSZ(in)
+		case EthConsensusVersionDeneb:
+			out.Version = spec.DataVersionDeneb
+			out.Deneb = new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
+			return out.Deneb.UnmarshalSSZ(in)
+		case EthConsensusVersionElectra:
+			out.Version = spec.DataVersionElectra
+			out.Electra = new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+			return out.Electra.UnmarshalSSZ(in)
+		case EthConsensusVersionFulu:
+			out.Version = spec.DataVersionFulu
+			out.Fulu = new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+			return out.Fulu.UnmarshalSSZ(in)
+		default:
+			return errInvalidForkVersion
 		}
-		return errFailedToDecode
+	case MediaTypeJSON:
+		if ethConsensusVersion == "" {
+			return types.ErrMissingEthConsensusVersion
+		}
+		var err error
+		switch ethConsensusVersion {
+		case EthConsensusVersionBellatrix:
+			bellatrixBlock := new(eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
+			err = json.Unmarshal(in, bellatrixBlock)
+			if err == nil {
+				out.Version = spec.DataVersionBellatrix
+				out.Bellatrix = bellatrixBlock
+			}
+		case EthConsensusVersionCapella:
+			capellaBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
+			err = json.Unmarshal(in, capellaBlock)
+			if err == nil {
+				out.Version = spec.DataVersionCapella
+				out.Capella = capellaBlock
+			}
+		case EthConsensusVersionDeneb:
+			denebBlock := new(eth2ApiV1Deneb.SignedBlindedBeaconBlock)
+			err = json.Unmarshal(in, denebBlock)
+			if err == nil {
+				out.Version = spec.DataVersionDeneb
+				out.Deneb = denebBlock
+			}
+		case EthConsensusVersionElectra:
+			electraBlock := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+			err = json.Unmarshal(in, electraBlock)
+			if err == nil {
+				out.Version = spec.DataVersionElectra
+				out.Electra = electraBlock
+			}
+		case EthConsensusVersionFulu:
+			fuluBlock := new(eth2ApiV1Electra.SignedBlindedBeaconBlock)
+			err = json.Unmarshal(in, fuluBlock)
+			if err == nil {
+				out.Version = spec.DataVersionFulu
+				out.Fulu = fuluBlock
+			}
+		default:
+			return errInvalidForkVersion
+		}
+		return err
 	}
 	return types.ErrInvalidContentType
 }
@@ -467,29 +513,32 @@ func decodeSignedBlindedBeaconBlock(in []byte, contentType, ethConsensusVersion 
 func decodeSubmitBlindedBlockResponse(in []byte, contentType, ethConsensusVersion string, out *builderApi.VersionedSubmitBlindedBlockResponse) error {
 	switch contentType {
 	case MediaTypeOctetStream:
-		if ethConsensusVersion != "" {
-			switch ethConsensusVersion {
-			case EthConsensusVersionBellatrix:
-				out.Version = spec.DataVersionBellatrix
-				out.Bellatrix = new(bellatrix.ExecutionPayload)
-				return out.Bellatrix.UnmarshalSSZ(in)
-			case EthConsensusVersionCapella:
-				out.Version = spec.DataVersionCapella
-				out.Capella = new(capella.ExecutionPayload)
-				return out.Capella.UnmarshalSSZ(in)
-			case EthConsensusVersionDeneb:
-				out.Version = spec.DataVersionDeneb
-				out.Deneb = new(builderApiDeneb.ExecutionPayloadAndBlobsBundle)
-				return out.Deneb.UnmarshalSSZ(in)
-			case EthConsensusVersionElectra:
-				out.Version = spec.DataVersionElectra
-				out.Electra = new(builderApiDeneb.ExecutionPayloadAndBlobsBundle)
-				return out.Electra.UnmarshalSSZ(in)
-			default:
-				return errInvalidForkVersion
-			}
-		} else {
+		if ethConsensusVersion == "" {
 			return types.ErrMissingEthConsensusVersion
+		}
+		switch ethConsensusVersion {
+		case EthConsensusVersionBellatrix:
+			out.Version = spec.DataVersionBellatrix
+			out.Bellatrix = new(bellatrix.ExecutionPayload)
+			return out.Bellatrix.UnmarshalSSZ(in)
+		case EthConsensusVersionCapella:
+			out.Version = spec.DataVersionCapella
+			out.Capella = new(capella.ExecutionPayload)
+			return out.Capella.UnmarshalSSZ(in)
+		case EthConsensusVersionDeneb:
+			out.Version = spec.DataVersionDeneb
+			out.Deneb = new(builderApiDeneb.ExecutionPayloadAndBlobsBundle)
+			return out.Deneb.UnmarshalSSZ(in)
+		case EthConsensusVersionElectra:
+			out.Version = spec.DataVersionElectra
+			out.Electra = new(builderApiDeneb.ExecutionPayloadAndBlobsBundle)
+			return out.Electra.UnmarshalSSZ(in)
+		case EthConsensusVersionFulu:
+			out.Version = spec.DataVersionFulu
+			out.Fulu = new(builderApiFulu.ExecutionPayloadAndBlobsBundle)
+			return out.Fulu.UnmarshalSSZ(in)
+		default:
+			return errInvalidForkVersion
 		}
 	case MediaTypeJSON:
 		return json.Unmarshal(in, out)
@@ -531,6 +580,9 @@ func (m *BoostService) respondGetPayloadSSZ(w http.ResponseWriter, result *build
 	case spec.DataVersionElectra:
 		w.Header().Set(HeaderEthConsensusVersion, EthConsensusVersionElectra)
 		sszData, err = result.Electra.MarshalSSZ()
+	case spec.DataVersionFulu:
+		w.Header().Set(HeaderEthConsensusVersion, EthConsensusVersionFulu)
+		sszData, err = result.Fulu.MarshalSSZ()
 	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair:
 		err = errInvalidForkVersion
 	}

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -339,7 +339,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 		log.WithError(err).Error("failed to get response blobs bundle")
 		return err
 	}
-	
+
 	// Check commitments
 	responseCommitments, err := responseBlobsBundle.Commitments()
 	if err != nil {
@@ -372,7 +372,7 @@ func verifyBlobsBundle(log *logrus.Entry, request *eth2Api.VersionedSignedBlinde
 	}
 
 	if request.Version >= spec.DataVersionFulu {
-		if len(requestCommitments) * common.CellsPerExtBlob != len(responseProofs) {
+		if len(requestCommitments)*common.CellsPerExtBlob != len(responseProofs) {
 			log.WithFields(logrus.Fields{
 				"requestBlobCommitments": len(requestCommitments),
 				"responseProofs":         len(responseProofs),

--- a/server/mock/mock_relay.go
+++ b/server/mock/mock_relay.go
@@ -272,6 +272,31 @@ func (m *Relay) MakeGetHeaderResponse(value uint64, blockHash, parentHash, publi
 				Signature: signature,
 			},
 		}
+	case spec.DataVersionFulu:
+		message := &builderApiElectra.BuilderBid{
+			Header: &deneb.ExecutionPayloadHeader{
+				BlockHash:       HexToHash(blockHash),
+				ParentHash:      HexToHash(parentHash),
+				WithdrawalsRoot: phase0.Root{},
+				BaseFeePerGas:   uint256.NewInt(0),
+			},
+			BlobKZGCommitments: make([]deneb.KZGCommitment, 0),
+			ExecutionRequests:  &electra.ExecutionRequests{},
+			Value:              uint256.NewInt(value),
+			Pubkey:             HexToPubkey(publicKey),
+		}
+
+		// Sign the message.
+		signature, err := ssz.SignMessage(message, ssz.DomainBuilder, m.secretKey)
+		require.NoError(m.t, err)
+
+		return &builderSpec.VersionedSignedBuilderBid{
+			Version: spec.DataVersionFulu,
+			Fulu: &builderApiElectra.SignedBuilderBid{
+				Message:   message,
+				Signature: signature,
+			},
+		}
 	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return nil
 	}

--- a/server/params/paths.go
+++ b/server/params/paths.go
@@ -2,8 +2,9 @@ package params
 
 const (
 	// Router paths
-	PathStatus            = "/eth/v1/builder/status"
-	PathRegisterValidator = "/eth/v1/builder/validators"
-	PathGetHeader         = "/eth/v1/builder/header/{slot:[0-9]+}/{parent_hash:0x[a-fA-F0-9]+}/{pubkey:0x[a-fA-F0-9]+}"
-	PathGetPayload        = "/eth/v1/builder/blinded_blocks"
+	PathStatus             = "/eth/v1/builder/status"
+	PathRegisterValidator  = "/eth/v1/builder/validators"
+	PathGetHeader          = "/eth/v1/builder/header/{slot:[0-9]+}/{parent_hash:0x[a-fA-F0-9]+}/{pubkey:0x[a-fA-F0-9]+}"
+	PathGetPayload         = "/eth/v1/builder/blinded_blocks"
+	PathSubmitBlindedBlock = "/eth/v2/builder/blinded_blocks"
 )

--- a/server/service.go
+++ b/server/service.go
@@ -153,6 +153,7 @@ func (m *BoostService) getRouter() http.Handler {
 	r.HandleFunc(params.PathRegisterValidator, m.handleRegisterValidator).Methods(http.MethodPost)
 	r.HandleFunc(params.PathGetHeader, m.handleGetHeader).Methods(http.MethodGet)
 	r.HandleFunc(params.PathGetPayload, m.handleGetPayload).Methods(http.MethodPost)
+	r.HandleFunc(params.PathSubmitBlindedBlock, m.handleSubmitBlindedBlock).Methods(http.MethodPost)
 
 	r.Use(mux.CORSMethodMiddleware(r))
 	loggedRouter := httplogger.LoggingMiddlewareLogrus(m.log, r)
@@ -337,6 +338,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	}
 }
 
+// Depreciated: For reference: https://github.com/ethereum/builder-specs/issues/119
 // handleGetPayload requests the payload from the relays
 func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request) {
 	var (
@@ -402,6 +404,47 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 		log.Error(message)
 		m.respondError(w, http.StatusNotAcceptable, message)
 	}
+}
+
+// handleSubmitBlindedBlock requests the payload submission from the relays but does not return the execution payload and blobs
+func (m *BoostService) handleSubmitBlindedBlock(w http.ResponseWriter, req *http.Request) {
+	var (
+		userAgent                   = wrapUserAgent(UserAgent(req.Header.Get(HeaderUserAgent)))
+		proposerContentType         = req.Header.Get(HeaderContentType)
+		proposerEthConsensusVersion = req.Header.Get(HeaderEthConsensusVersion)
+		acceptContentType           = "application/json"
+	)
+
+	// Do the initial debug log
+	log := m.log.WithFields(logrus.Fields{
+		"method":                      "handleSubmitBlindedBlock",
+		"userAgent":                   userAgent,
+		"proposerContentType":         proposerContentType,
+		"proposerEthConsensusVersion": proposerEthConsensusVersion,
+	})
+	log.Debug("handling request")
+
+	// Read the body first, so we can log it later on error
+	signedBlindedBlockBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		log.WithError(err).Error("could not read body of request from the beacon node")
+		m.respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Submit the signed blinded beacon block to relays
+	success, originalBid := m.submitBlindedBlock(log, signedBlindedBlockBytes, userAgent, proposerContentType, acceptContentType, proposerEthConsensusVersion)
+
+	// If no relay accepted the submission, log about the failure
+	if !success {
+		originRelays := types.RelayEntriesToStrings(originalBid.relays)
+		log.WithField("relaysWithBid", strings.Join(originRelays, ", ")).Error("no relay accepted the signed blinded beacon block submission!")
+		m.respondError(w, http.StatusBadGateway, errNoSuccessfulRelayResponse.Error())
+		return
+	}
+
+	log.Info("successfully submitted signed blinded beacon block to relay")
+	w.WriteHeader(http.StatusAccepted)
 }
 
 // CheckRelays sends a request to each one of the relays previously registered to get their status

--- a/server/service.go
+++ b/server/service.go
@@ -338,7 +338,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 	}
 }
 
-// Depreciated: For reference: https://github.com/ethereum/builder-specs/issues/119
+// Deprecated: For reference: https://github.com/ethereum/builder-specs/issues/119
 // handleGetPayload requests the payload from the relays
 func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request) {
 	var (

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -18,6 +18,7 @@ import (
 
 	builderApi "github.com/attestantio/go-builder-client/api"
 	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiFulu "github.com/attestantio/go-builder-client/api/fulu"
 	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	builderSpec "github.com/attestantio/go-builder-client/spec"
 	eth2Api "github.com/attestantio/go-eth2-client/api"
@@ -1134,10 +1135,13 @@ func TestEmptyTxRoot(t *testing.T) {
 	require.Equal(t, "0x7ffe241ea60187fdb0187bfa22de35d1f9bed7ab061d9401fd47e34a54fbede1", txRootHex)
 }
 
-func blindedBlockToBlockResponse(signedBlock any) *builderApi.VersionedSubmitBlindedBlockResponse {
-	// TODO(jtraglia): How do we update this to work with Fulu too?
-	switch block := signedBlock.(type) {
-	case *eth2ApiV1Bellatrix.SignedBlindedBeaconBlock:
+func blindedBlockToBlockResponse(signedBlock any, version spec.DataVersion) *builderApi.VersionedSubmitBlindedBlockResponse {
+	switch version {
+	case spec.DataVersionBellatrix:
+		block, ok := signedBlock.(*eth2ApiV1Bellatrix.SignedBlindedBeaconBlock)
+		if !ok {
+			panic("failed to convert block")
+		}
 		header := block.Message.Body.ExecutionPayloadHeader
 		return &builderApi.VersionedSubmitBlindedBlockResponse{
 			Version: spec.DataVersionBellatrix,
@@ -1158,7 +1162,11 @@ func blindedBlockToBlockResponse(signedBlock any) *builderApi.VersionedSubmitBli
 				Transactions:  make([]bellatrix.Transaction, 0),
 			},
 		}
-	case *eth2ApiV1Capella.SignedBlindedBeaconBlock:
+	case spec.DataVersionCapella:
+		block, ok := signedBlock.(*eth2ApiV1Capella.SignedBlindedBeaconBlock)
+		if !ok {
+			panic("failed to convert block")
+		}
 		header := block.Message.Body.ExecutionPayloadHeader
 		return &builderApi.VersionedSubmitBlindedBlockResponse{
 			Version: spec.DataVersionCapella,
@@ -1180,20 +1188,41 @@ func blindedBlockToBlockResponse(signedBlock any) *builderApi.VersionedSubmitBli
 				Withdrawals:   make([]*capella.Withdrawal, 0),
 			},
 		}
-	case *eth2ApiV1Deneb.SignedBlindedBeaconBlock:
+	case spec.DataVersionDeneb:
+		block, ok := signedBlock.(*eth2ApiV1Deneb.SignedBlindedBeaconBlock)
+		if !ok {
+			panic("failed to convert block")
+		}
 		header := block.Message.Body.ExecutionPayloadHeader
 		commitments := block.Message.Body.BlobKZGCommitments
 		return &builderApi.VersionedSubmitBlindedBlockResponse{
 			Version: spec.DataVersionDeneb,
 			Deneb:   denebExecutionPayloadAndBlobsBundle(header, commitments),
 		}
-	case *eth2ApiV1Electra.SignedBlindedBeaconBlock:
+	case spec.DataVersionElectra:
+		block, ok := signedBlock.(*eth2ApiV1Electra.SignedBlindedBeaconBlock)
+		if !ok {
+			panic("failed to convert block")
+		}
 		header := block.Message.Body.ExecutionPayloadHeader
 		commitments := block.Message.Body.BlobKZGCommitments
 		return &builderApi.VersionedSubmitBlindedBlockResponse{
 			Version: spec.DataVersionElectra,
 			Electra: denebExecutionPayloadAndBlobsBundle(header, commitments),
 		}
+	case spec.DataVersionFulu:
+		block, ok := signedBlock.(*eth2ApiV1Electra.SignedBlindedBeaconBlock)
+		if !ok {
+			panic("failed to convert block")
+		}
+		header := block.Message.Body.ExecutionPayloadHeader
+		commitments := block.Message.Body.BlobKZGCommitments
+		return &builderApi.VersionedSubmitBlindedBlockResponse{
+			Version: spec.DataVersionFulu,
+			Fulu:    fuluExecutionPayloadAndBlobsBundle(header, commitments),
+		}
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair:
+		panic("unknown data version")
 	}
 	return nil
 }
@@ -1226,6 +1255,41 @@ func denebExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, k
 			ExcessBlobGas: header.ExcessBlobGas,
 		},
 		BlobsBundle: &builderApiDeneb.BlobsBundle{
+			Commitments: commitments,
+			Proofs:      proofs,
+			Blobs:       blobs,
+		},
+	}
+}
+
+func fuluExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, kzgCommitments []deneb.KZGCommitment) *builderApiFulu.ExecutionPayloadAndBlobsBundle {
+	numBlobs := len(kzgCommitments)
+	commitments := make([]deneb.KZGCommitment, numBlobs)
+	copy(commitments, kzgCommitments)
+	// For testing, proofs and blobs are not populated
+	proofs := make([]deneb.KZGProof, numBlobs)
+	blobs := make([]deneb.Blob, numBlobs)
+	return &builderApiFulu.ExecutionPayloadAndBlobsBundle{
+		ExecutionPayload: &deneb.ExecutionPayload{
+			ParentHash:    header.ParentHash,
+			FeeRecipient:  header.FeeRecipient,
+			StateRoot:     header.StateRoot,
+			ReceiptsRoot:  header.ReceiptsRoot,
+			LogsBloom:     header.LogsBloom,
+			PrevRandao:    header.PrevRandao,
+			BlockNumber:   header.BlockNumber,
+			GasLimit:      header.GasLimit,
+			GasUsed:       header.GasUsed,
+			Timestamp:     header.Timestamp,
+			ExtraData:     header.ExtraData,
+			BaseFeePerGas: header.BaseFeePerGas,
+			BlockHash:     header.BlockHash,
+			Transactions:  make([]bellatrix.Transaction, 0),
+			Withdrawals:   make([]*capella.Withdrawal, 0),
+			BlobGasUsed:   header.BlobGasUsed,
+			ExcessBlobGas: header.ExcessBlobGas,
+		},
+		BlobsBundle: &builderApiFulu.BlobsBundle{
 			Commitments: commitments,
 			Proofs:      proofs,
 			Blobs:       blobs,
@@ -1300,7 +1364,7 @@ func TestGetPayloadForks(t *testing.T) {
 			}
 
 			// Configure the relay's expected response and send the request
-			backend.relays[0].GetPayloadResponse = blindedBlockToBlockResponse(payload)
+			backend.relays[0].GetPayloadResponse = blindedBlockToBlockResponse(payload, block.Version)
 			rr := backend.request(t, http.MethodPost, params.PathGetPayload, header, payload)
 
 			// Validate the response
@@ -1352,7 +1416,7 @@ func TestGetPayloadToAllRelays(t *testing.T) {
 	require.Equal(t, 1, backend.relays[1].GetRequestCount(getHeaderPath))
 
 	// Prepare getPayload response
-	backend.relays[0].GetPayloadResponse = blindedBlockToBlockResponse(signedBlindedBeaconBlock)
+	backend.relays[0].GetPayloadResponse = blindedBlockToBlockResponse(signedBlindedBeaconBlock, spec.DataVersionDeneb)
 
 	// call getPayload, ensure it's called to all relays
 	rr = backend.request(t, http.MethodPost, params.PathGetPayload, header, signedBlindedBeaconBlock)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	eth2UtilBellatrix "github.com/attestantio/go-eth2-client/util/bellatrix"
+	"github.com/flashbots/mev-boost/common"
 	"github.com/flashbots/mev-boost/server/mock"
 	"github.com/flashbots/mev-boost/server/params"
 	"github.com/flashbots/mev-boost/server/types"
@@ -1313,7 +1314,7 @@ func fuluExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, kz
 	commitments := make([]deneb.KZGCommitment, numBlobs)
 	copy(commitments, kzgCommitments)
 	// For testing, proofs and blobs are not populated
-	proofs := make([]deneb.KZGProof, numBlobs)
+	proofs := make([]deneb.KZGProof, numBlobs * common.CellsPerExtBlob)
 	blobs := make([]deneb.Blob, numBlobs)
 	return &builderApiFulu.ExecutionPayloadAndBlobsBundle{
 		ExecutionPayload: &deneb.ExecutionPayload{

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,6 +35,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	eth2UtilBellatrix "github.com/attestantio/go-eth2-client/util/bellatrix"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/flashbots/mev-boost/common"
 	"github.com/flashbots/mev-boost/server/mock"
 	"github.com/flashbots/mev-boost/server/params"
@@ -1281,6 +1283,9 @@ func denebExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, k
 	// For testing, proofs and blobs are not populated
 	proofs := make([]deneb.KZGProof, numBlobs)
 	blobs := make([]deneb.Blob, numBlobs)
+
+	// TODO - add blobs, commitments and proofs for deneb
+
 	return &builderApiDeneb.ExecutionPayloadAndBlobsBundle{
 		ExecutionPayload: &deneb.ExecutionPayload{
 			ParentHash:    header.ParentHash,
@@ -1314,8 +1319,38 @@ func fuluExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, kz
 	commitments := make([]deneb.KZGCommitment, numBlobs)
 	copy(commitments, kzgCommitments)
 	// For testing, proofs and blobs are not populated
-	proofs := make([]deneb.KZGProof, numBlobs * common.CellsPerExtBlob)
+	proofs := make([]deneb.KZGProof, 0, numBlobs * common.CellsPerExtBlob)
 	blobs := make([]deneb.Blob, numBlobs)
+
+	for i := 0; i < numBlobs; i++ {
+		blobData, err := randomBlobData(deneb.BlobLength)
+		if err != nil {
+			panic(err)
+		}
+		blobs[i] = deneb.Blob(blobData)
+	}
+	// generate kzg commitments
+	for i := 0; i < numBlobs; i++ {
+		convertedBlob := kzg4844.Blob(blobs[i])
+		commitment, err := kzg4844.BlobToCommitment(&convertedBlob)
+		if err != nil {
+			panic(err)
+		}
+		commitments[i] = deneb.KZGCommitment(commitment)
+	}
+	for i := 0; i < numBlobs; i++ {
+		convertedBlob := kzg4844.Blob(blobs[i])
+		proof, err := kzg4844.ComputeCells(&convertedBlob)
+		if err != nil {
+			panic(err)
+		}
+		denebProofs := make([]deneb.KZGProof, len(proof))
+		for j := 0; j < len(proof); j++ {
+			denebProofs[j] = deneb.KZGProof(proof[j])
+		}
+		proofs = append(proofs, denebProofs...)
+	}
+
 	return &builderApiFulu.ExecutionPayloadAndBlobsBundle{
 		ExecutionPayload: &deneb.ExecutionPayload{
 			ParentHash:    header.ParentHash,
@@ -1342,6 +1377,21 @@ func fuluExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, kz
 			Blobs:       blobs,
 		},
 	}
+}
+
+// randomBlobData generates cryptographically secure random blob data of the specified size.
+// Uses crypto/rand for secure random number generation.
+// Returns an error if the random data generation fails or doesn't produce the requested size.
+func randomBlobData(size int) ([]byte, error) {
+	data := make([]byte, size)
+	n, err := rand.Read(data)
+	if err != nil {
+		return nil, err
+	}
+	if n != size {
+		return nil, fmt.Errorf("could not create random blob data with size %d: %v", size, err)
+	}
+	return data, nil
 }
 
 func TestGetPayloadForks(t *testing.T) {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -796,6 +797,7 @@ func TestGetPayload(t *testing.T) {
 	t.Run("Okay response from relay in JSON", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
 
 		backend := newTestBackend(t, 1, time.Second)
 
@@ -976,6 +978,7 @@ func TestGetPayload(t *testing.T) {
 	t.Run("Bad response from relays", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
 
 		backend := newTestBackend(t, 2, time.Second)
 
@@ -1024,6 +1027,7 @@ func TestGetPayload(t *testing.T) {
 	t.Run("Retries on error from relay", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
 
 		backend := newTestBackend(t, 1, 2*time.Second)
 
@@ -1053,6 +1057,7 @@ func TestGetPayload(t *testing.T) {
 	t.Run("Error after max retries are reached", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
 
 		backend := newTestBackend(t, 1, time.Second)
 
@@ -1130,6 +1135,7 @@ func TestEmptyTxRoot(t *testing.T) {
 }
 
 func blindedBlockToBlockResponse(signedBlock any) *builderApi.VersionedSubmitBlindedBlockResponse {
+	// TODO(jtraglia): How do we update this to work with Fulu too?
 	switch block := signedBlock.(type) {
 	case *eth2ApiV1Bellatrix.SignedBlindedBeaconBlock:
 		header := block.Message.Body.ExecutionPayloadHeader
@@ -1230,9 +1236,6 @@ func denebExecutionPayloadAndBlobsBundle(header *deneb.ExecutionPayloadHeader, k
 func TestGetPayloadForks(t *testing.T) {
 	t.Parallel()
 
-	header := http.Header{}
-	header.Set("Accept", "application/json")
-
 	// Get a list of testdata files
 	pattern := "../testdata/signed-blinded-beacon-block-*.json"
 	files, err := filepath.Glob(pattern)
@@ -1248,12 +1251,22 @@ func TestGetPayloadForks(t *testing.T) {
 			jsonBytes, err := os.ReadFile(file)
 			require.NoError(t, err)
 
+			re := regexp.MustCompile(`^.*signed-blinded-beacon-block-(.+)\.json$`)
+			matches := re.FindStringSubmatch(file)
+			require.Len(t, matches, 2, "filename did not match expected pattern")
+			consensusVersion := matches[1]
+
+			header := http.Header{}
+			header.Set("Accept", "application/json")
+			header.Set("Content-Type", "application/json")
+			header.Set("Eth-Consensus-Version", consensusVersion)
+
 			// Create a new backend
 			backend := newTestBackend(t, 1, time.Second)
 
 			// Decode the block
 			block := new(eth2Api.VersionedSignedBlindedBeaconBlock)
-			err = decodeSignedBlindedBeaconBlock(jsonBytes, MediaTypeJSON, "", block)
+			err = decodeSignedBlindedBeaconBlock(jsonBytes, MediaTypeJSON, consensusVersion, block)
 			require.NoError(t, err)
 
 			// Get the request slot and block hash
@@ -1280,6 +1293,8 @@ func TestGetPayloadForks(t *testing.T) {
 				payload = block.Deneb
 			case spec.DataVersionElectra:
 				payload = block.Electra
+			case spec.DataVersionFulu:
+				payload = block.Fulu
 			case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair:
 				require.Fail(t, "unsupported version")
 			}
@@ -1303,6 +1318,7 @@ func TestGetPayloadForks(t *testing.T) {
 func TestGetPayloadToAllRelays(t *testing.T) {
 	header := make(http.Header)
 	header.Set(HeaderAccept, MediaTypeJSON)
+	header.Set("Eth-Consensus-Version", "deneb")
 
 	// Load the signed blinded beacon block used for getPayload
 	jsonFile, err := os.Open("../testdata/signed-blinded-beacon-block-deneb.json")

--- a/server/submit_blinded_block.go
+++ b/server/submit_blinded_block.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime"
+	"net/http"
+	"slices"
+	"sync/atomic"
+	"time"
+
+	eth2Api "github.com/attestantio/go-eth2-client/api"
+	"github.com/flashbots/mev-boost/config"
+	"github.com/flashbots/mev-boost/server/params"
+	"github.com/flashbots/mev-boost/server/types"
+	"github.com/sirupsen/logrus"
+)
+
+// submitBlindedBlock submits the signed blinded beacon block to relays for submission without returning the full payload
+func (m *BoostService) submitBlindedBlock(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (bool, bidResp) {
+	// Get the request's content type
+	parsedProposerContentType, _, err := mime.ParseMediaType(proposerContentType)
+	if err != nil {
+		log.WithError(err).Warn("failed to parse proposer content type")
+		parsedProposerContentType = MediaTypeJSON
+	}
+	log = log.WithField("parsedProposerContentType", parsedProposerContentType)
+
+	// Decode the request
+	request := new(eth2Api.VersionedSignedBlindedBeaconBlock)
+	err = decodeSignedBlindedBeaconBlock(signedBlindedBeaconBlockBytes, parsedProposerContentType, proposerEthConsensusVersion, request)
+	if err != nil {
+		log.WithError(err).Error("failed to decode signed blinded beacon block")
+		return false, bidResp{}
+	}
+
+	// Get information about the request
+	slot, err := request.Slot()
+	if err != nil {
+		log.WithError(err).Error("failed to get request slot")
+		return false, bidResp{}
+	}
+	blockHash, err := request.ExecutionBlockHash()
+	if err != nil {
+		log.WithError(err).Error("failed to get request block hash")
+		return false, bidResp{}
+	}
+	parentHash, err := request.ExecutionParentHash()
+	if err != nil {
+		log.WithError(err).Error("failed to get request parent hash")
+		return false, bidResp{}
+	}
+
+	// Get the currentSlotUID for this slot
+	currentSlotUID := ""
+	m.slotUIDLock.Lock()
+	if m.slotUID.slot == slot {
+		currentSlotUID = m.slotUID.uid.String()
+	} else {
+		log.Warnf("latest slotUID is for slot %d rather than payload slot %d", m.slotUID.slot, slot)
+	}
+	m.slotUIDLock.Unlock()
+
+	// Prepare logger
+	log = log.WithFields(logrus.Fields{
+		"slot":       slot,
+		"blockHash":  blockHash.String(),
+		"parentHash": parentHash.String(),
+		"slotUID":    currentSlotUID,
+	})
+
+	// Log how late into the slot the request starts
+	slotStartTimestamp := m.genesisTime + uint64(slot)*config.SlotTimeSec
+	msIntoSlot := uint64(time.Now().UTC().UnixMilli()) - slotStartTimestamp*1000
+	log.WithFields(logrus.Fields{
+		"genesisTime": m.genesisTime,
+		"slotTimeSec": config.SlotTimeSec,
+		"msIntoSlot":  msIntoSlot,
+	}).Infof("submitBlindedBlock request start - %d milliseconds into slot %d", msIntoSlot, slot)
+
+	// Get the bid!
+	m.bidsLock.Lock()
+	originalBid := m.bids[bidKey(slot, blockHash)]
+	m.bidsLock.Unlock()
+	if originalBid.response.IsEmpty() {
+		log.Error("no bid for this payload found, was getHeader called before?")
+	} else if len(originalBid.relays) == 0 {
+		log.Warn("bid found but no associated relays")
+	}
+
+	// Prepare for requests
+	resultCh := make(chan bool, len(m.relays))
+	var received atomic.Bool
+	go func() {
+		// Make sure we receive a response within the timeout
+		time.Sleep(m.httpClientGetPayload.Timeout)
+		resultCh <- false
+	}()
+
+	// Create a context with a timeout as configured in the http client
+	requestCtx, requestCtxCancel := context.WithTimeout(context.Background(), m.httpClientGetPayload.Timeout)
+	defer requestCtxCancel()
+
+	for _, relay := range m.relays {
+		go func(relay types.RelayEntry) {
+			url := relay.GetURI(params.PathSubmitBlindedBlock)
+			log := log.WithField("url", url)
+			log.Debug("calling submit payload")
+
+			// If the request fails, try again a few times with 100ms between tries
+			resp, err := retry(requestCtx, m.requestMaxRetries, 100*time.Millisecond, func() (*http.Response, error) {
+				// Default to the content from the proposer
+				requestContentType := parsedProposerContentType
+				requestBytes := signedBlindedBeaconBlockBytes
+
+				// Check if the relay supports SSZ
+				relaySupportsSSZ := false
+				for _, originalBidRelay := range originalBid.relays {
+					if relay.URL == originalBidRelay.URL {
+						relaySupportsSSZ = originalBidRelay.SupportsSSZ
+						break
+					}
+				}
+				log.WithField("relaySupportsSSZ", relaySupportsSSZ).Debug("encoding preference")
+
+				// If the relay provided the bid in JSON or did not provide a bid for this payload,
+				// we must convert the signed blinded beacon block from SSZ to JSON for this relay
+				if parsedProposerContentType == MediaTypeOctetStream && !relaySupportsSSZ {
+					requestContentType = MediaTypeJSON
+					startTime := time.Now()
+					requestBytes, err = convertSSZToJSON(proposerEthConsensusVersion, signedBlindedBeaconBlockBytes)
+					if err != nil {
+						log.WithError(errFailedToConvert).Error("failed to convert SSZ to JSON")
+						return nil, err
+					}
+					log.WithFields(logrus.Fields{
+						"relayProvidedBid": slices.Contains(originalBid.relays, relay),
+						"conversionTime":   time.Since(startTime),
+					}).Info("Converted request from SSZ to JSON for relay")
+				}
+
+				// Make a new request
+				req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, url, bytes.NewReader(requestBytes))
+				if err != nil {
+					log.WithError(err).Warn("error creating new request")
+					return nil, err
+				}
+
+				// Add header fields to this request
+				req.Header.Set(HeaderAccept, proposerAcceptContentTypes)
+				req.Header.Set(HeaderContentType, requestContentType)
+				req.Header.Set(HeaderEthConsensusVersion, proposerEthConsensusVersion)
+				req.Header.Set(HeaderKeySlotUID, currentSlotUID)
+				req.Header.Set(HeaderDateMilliseconds, fmt.Sprintf("%d", time.Now().UTC().UnixMilli()))
+				req.Header.Set(HeaderUserAgent, userAgent)
+
+				// Send the request
+				log.Debug("requesting payload submission")
+				resp, err := m.httpClientGetPayload.Do(req)
+				if err != nil {
+					log.WithError(err).Warn("error calling submit payload on relay")
+					return nil, err
+				}
+
+				// Check that the response was accepted 202
+				if resp.StatusCode != http.StatusAccepted {
+					err = fmt.Errorf("%w: %d", errHTTPErrorResponse, resp.StatusCode)
+					log.WithError(err).Warn("error status code")
+					return nil, err
+				}
+
+				return resp, nil
+			})
+			if err != nil {
+				log.WithError(err).Warn("failed to request submit payload after retries")
+				return
+			}
+			defer resp.Body.Close()
+
+			log.Info("relay accepted signed blinded beacon block submission")
+
+			// request is accepted cancel other calls.
+			requestCtxCancel()
+
+			// We have received a successful submission, cancel other requests
+			if received.CompareAndSwap(false, true) {
+				resultCh <- true
+				log.Info("successfully submitted blinded block to relay")
+			} else {
+				log.Trace("discarding response, already received a successful submission")
+			}
+		}(relay)
+	}
+
+	// Wait for the first request to complete
+	return <-resultCh, originalBid
+}

--- a/server/utils.go
+++ b/server/utils.go
@@ -223,6 +223,12 @@ func getPayloadResponseIsEmpty(payload *builderApi.VersionedSubmitBlindedBlockRe
 			payload.Electra.BlobsBundle == nil {
 			return true
 		}
+	case spec.DataVersionFulu:
+		if payload.Fulu == nil || payload.Fulu.ExecutionPayload == nil ||
+			payload.Fulu.ExecutionPayload.BlockHash == nilHash ||
+			payload.Fulu.BlobsBundle == nil {
+			return true
+		}
 	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair:
 		return true
 	}

--- a/testdata/signed-blinded-beacon-block-fulu.json
+++ b/testdata/signed-blinded-beacon-block-fulu.json
@@ -1,0 +1,72 @@
+{
+  "message": {
+    "slot": "252288",
+    "proposer_index": "4295",
+    "parent_root": "0x9a8eef2096477e645150fee1a2ce13190382179a0ea843f31173715a1a14e074",
+    "state_root": "0x4c033e0b4a34c0eb8e0caba126fae3ed303a83254fe39f8daaa673125f4042cc",
+    "body": {
+      "randao_reveal": "0xa7a74e03d8ef909abc75b9452d167e15869180fb4b19db79a1136b510495f02d6ae480ee4ad6a2a9e41af866a9a54c681601a3a1dee30f676e93e6c6b3eb3e880c2cb8d32bd730ca9e7def92877c70da09bfc52a531f1be15619c8a3bb38bdf6",
+      "eth1_data": {
+        "deposit_root": "0x0cacd599c9cdcee8398b40ef045baf2c137bed4d2b02a465a0414b04015f861d",
+        "deposit_count": "216773",
+        "block_hash": "0xd75a680056c50b4e339eda2f91ccd33badc5d59feab830526e342c5ec68d8dce"
+      },
+      "graffiti": "0x6c69676874686f7573652d6e65746865726d696e642d33000000000000000000",
+      "proposer_slashings": [],
+      "attester_slashings": [],
+      "attestations": [
+        {
+          "aggregation_bits": "0xf8fbff9093195acfebcff69cdfef71fbd9eaf19777f7dfb1f9233faf08be7e463a675cefef2d9e03",
+          "data": {
+            "slot": "252287",
+            "index": "0",
+            "beacon_block_root": "0x9a8eef2096477e645150fee1a2ce13190382179a0ea843f31173715a1a14e074",
+            "source": {
+              "epoch": "7682",
+              "root": "0x83900465836d88fbd48a829ca207db86e32aa7797966df1b0c886128c72a1a0b"
+            },
+            "target": {
+              "epoch": "7883",
+              "root": "0x6e20c4503b853781327d750ee818651e5493b04f5ea0f2699725eecb1e0c3ddf"
+            }
+          },
+          "signature": "0xb8fb8248ce16152eb41f88803445ef64c33da86de7bfd398b12e745a449013f9454c38b42a658291e344e3eb11d1c3ec03d692b9ed299aff0f599ea9145596b5195d11ff49f83a573519616c8b76c9459a1ed5f869e1c5c6bad176adbd3b689c",
+          "committee_bits": "0x0300000000000000"
+        }
+      ],
+      "deposits": [],
+      "voluntary_exits": [],
+      "sync_aggregate": {
+        "sync_committee_bits": "0xde98bcde844ff76e87b94cfff1cbcc3dfbf93fdf3ee9b994764fafe484f762eb1562e7fa28e96f5d7a887bff689ffb932d5eff467e668d137bc565d37e3fa7fd",
+        "sync_committee_signature": "0x93a611fb577d17674242e42de06958513013b0cb07d1f284e993ed7d63ac43bbc234e54a886ca9cb979e76eabeeb6ee603556234b7d661bdb7a7ac98813028faf8060e5e9271d4f25de199ce5e2ecc2a6762a49c41bf366b1c4c54bc185c62f9"
+      },
+      "execution_payload_header": {
+        "parent_hash": "0x98b62322edaa4d91ecc0847fe2f7debc89dec5e808d7e369aa9b535543227f60",
+        "fee_recipient": "0xf97e180c050e5ab072211ad2c213eb5aee4df134",
+        "state_root": "0x3b6b594d5cbe7ff4c8bdca04f080c57a18fffdaf1c8e700e69b86f7425ed8d73",
+        "receipts_root": "0x04deb4be6955e1a300123be48007597f67e4229f8ce70f4f10388de6fd3fa267",
+        "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "prev_randao": "0x83612b3de54001f74bf36234e373c1fca95dab5e4645bc3faf7108345cf82e34",
+        "block_number": "220275",
+        "gas_limit": "30000000",
+        "gas_used": "84000",
+        "timestamp": "1732296378",
+        "extra_data": "0x4e65746865726d696e64",
+        "base_fee_per_gas": "7",
+        "block_hash": "0xb65b77e52407ff25f7fcd3f455c991ae67be1bc10cb7ec992a659698cf88870f",
+        "transactions_root": "0xb1fcd304d8ba402be6e76346395ea7641fbb4c83663b697a0e88ab115d859d3f",
+        "withdrawals_root": "0x792930bbd5baac43bcc798ee49aa8185ef76bb3b44ba62b91d86ae569e4bb535",
+        "blob_gas_used": "0",
+        "excess_blob_gas": "0"
+      },
+      "bls_to_execution_changes": [],
+      "blob_kzg_commitments": [],
+      "execution_requests": {
+        "deposits": [],
+        "withdrawals": [],
+        "consolidations": []
+      }
+    }
+  },
+  "signature": "0x94cd72a70a0b424f68145115a9a52f6c8557fb40ec8b67c26cbb9b324b72756624a59e8bbe11b78acbbb8e9c606035d10c0dab9a3f4177d7e6954f8ea1863d0b0b00007fb420b4b4cf52e065bda0ad32af0d3a71bd6938180bab6dd1af754d2f"
+}


### PR DESCRIPTION
## 📝 Summary

Introduces v2 blinded blocks endpoint which doesn't return the entire `ExecutionPayload` and `BlobsBundle`

## ⛱ Motivation and Context
Currently the `/eth/v1/builder/blinded_blocks` returns the entire `ExecutionPayload` and `BlobsBundle`. This can increase network bandwidth costs for the proposer and also the request time as we increase the number of Blobs. We therefore introduce a new v2 API endpoint, `/eth/v2/builder/blinded_blocks` which no longer returns the fully signed unblinded payload. Instead, it returns an empty response and relies on the relay to propagate the block.

## 📚 References

https://github.com/ethereum/builder-specs/issues/119
https://github.com/ethereum/builder-specs/pull/123

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
