### PR TITLE
Add X-timeout-ms header

### DIFF
--- a/server/constants.go
+++ b/server/constants.go
@@ -9,6 +9,8 @@ const (
 	HeaderUserAgent           = "User-Agent"
 	// Header which communicates when a request was sent. Used to measure latency.
 	HeaderDateMilliseconds = "Date-Milliseconds"
+	// Header which communicates timeout set by client. Used to tweak block creation delay together with Date-Milliseconds.
+	HeaderTimeoutMs = "X-Timeout-Ms"
 
 	MediaTypeJSON        = "application/json"
 	MediaTypeOctetStream = "application/octet-stream"

--- a/server/get_header.go
+++ b/server/get_header.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -89,6 +90,7 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 			req.Header.Set(HeaderKeySlotUID, slotUID.String())
 			req.Header.Set(HeaderUserAgent, userAgent)
 			req.Header.Set(HeaderDateMilliseconds, startTime)
+			req.Header.Set(HeaderTimeoutMs, strconv.FormatInt(m.httpClientGetHeader.Timeout.Milliseconds(), 10))
 
 			// Send the request
 			log.Debug("requesting header")


### PR DESCRIPTION
## 📝 Summary

`X-timeout-ms` HTTP header included in the `get_header` request to specify the timeout set to the request. Used by the relay in order to determine if and how much delay it can add to the block production.

## ⛱ Motivation and Context

We have encountered issues where a lower `get_header` request timeout resulted in only failures by the relays. This was caused as it's not uncommon for relays to delay the block creation in order to maximise the rewards. Relays on their end assume a default timeout in the range of 950-1000ms, so they adjust block production to that. However, reducing the HTTP request timeout does not reduce the delay they are using, resulting in failures to provide block header on time.

On Obol's side we have talked about that with multiple relay providers and most of them agreed to include `X-timeout-ms` HTTP header in the `get_header` HTTP request. Using this HTTP header and the `Date-Milliseconds` HTTP header, relays can calculate the timeout - the latency and adjust their block production delay accordingly.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
