### PR TITLE
fix: minor security improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #4.3.0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #4.3.0
 
       - name: Get tag version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #4.3.0
         with:
           fetch-depth: 0
       - name: Fetch all tags
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #4.3.0
         with:
           fetch-depth: 0
       - name: Fetch all tags

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         id: go
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #4.3.0
 
       - name: Run unit tests and generate the coverage report
         run: make test-coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.24 as builder
 ARG VERSION
 WORKDIR /build
 
-COPY go.mod ./
-COPY go.sum ./
+COPY go.mod go.sum ./
 
 RUN go mod download
 
@@ -12,12 +11,13 @@ ADD . .
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
     -v \
-    -ldflags "-w -s -X 'github.com/flashbots/mev-boost/config.Version=$VERSION'" \
+    -ldflags "-w -s -X github.com/flashbots/mev-boost/config.Version=${VERSION}" \
     -o mev-boost .
 
-FROM alpine
+FROM alpine:3.22
 WORKDIR /app
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/mev-boost /app/mev-boost
 EXPOSE 18550
+USER app
 ENTRYPOINT ["/app/mev-boost"]


### PR DESCRIPTION
## 📝 Summary

Minor security improvements

## ⛱ Motivation and Context

**CI**:
- Pin actions/checkout to a commit SHA (v4.3.0) across all workflows for supply-chain hardening and reproducible builds.

**Docker**:
- Streamline module copy step and improve build caching.
- Runtime container defaults to root; better to drop privileges.

**Other**
- I also want to draw attention to the following things that I did not change, as there may be flaws in this that I do not know about. 
- The golang image is built on Debian, it may be better to use the image on alpine ?
- Copying /etc/ssl/certs/ca-certificates.crt from the Debian-based builder into Alpine can work, but it’s brittle. It’s safer to install Alpine’s own ca-certificates. 
- Another security recommendation is to vendor all github actions as they may gain access to sensitive information

## 📚 References

[npm debug and chalk packages compromised ](https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised)

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
