### PR TITLE
update go-builder-client to 0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 )
 
 require (
-	github.com/attestantio/go-builder-client v0.7.0
+	github.com/attestantio/go-builder-client v0.7.1
 	github.com/attestantio/go-eth2-client v0.27.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
-github.com/attestantio/go-builder-client v0.7.0 h1:Kxf5eTKQlU4syv3Uzt8v3vKKm7im1W4CjRAZiPYoqTQ=
-github.com/attestantio/go-builder-client v0.7.0/go.mod h1:wGZ0U3QX8/F4lWwieJpqCPgXIl8gbfBxm8iViznrTFQ=
+github.com/attestantio/go-builder-client v0.7.1 h1:wKzmfuizxBE6q00Gguk71fHkcudwOcxn/W4uvll36Fo=
+github.com/attestantio/go-builder-client v0.7.1/go.mod h1:wGZ0U3QX8/F4lWwieJpqCPgXIl8gbfBxm8iViznrTFQ=
 github.com/attestantio/go-eth2-client v0.27.0 h1:zOXtDVnMNRwX6GjpJYgXUNsXckEx76pGRDi76i7xhSI=
 github.com/attestantio/go-eth2-client v0.27.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=


### PR DESCRIPTION
## 📝 Summary

Update go-builder-client to 0.7.1

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
