### PR TITLE
feat: fallback to v1 getPayload api if v2 getPayload api fails

### DIFF
--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -236,9 +236,9 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				// Check that the response was successful
 
 				// If the relay does not support V2 API, retry with V1 API
-				// we can fallback to V1 API if the status code returned >= 400. There is no harm 
-				// falling back to the V1 API, falling back to the V1 API in the case of any error 
-				// can be beneficial to the proposer to avoid a missed slot. 
+				// we can fallback to V1 API if the status code returned >= 400. There is no harm
+				// falling back to the V1 API, falling back to the V1 API in the case of any error
+				// can be beneficial to the proposer to avoid a missed slot.
 				if resp.StatusCode >= http.StatusBadRequest && url == relay.GetURI(params.PathGetPayloadV2) {
 					log.Warn("relay may not support V2 API, Retrying with V1 API")
 					// retry with v1 api

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -235,8 +235,12 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				RecordRelayStatusCode(strconv.Itoa(statusCode), endpoint, relay.String())
 				// Check that the response was successful
 
-				if resp.StatusCode == http.StatusNotFound && url == relay.GetURI(params.PathGetPayloadV2) {
-					log.Warn("relay may not support V2 API, Retrying with v1 API")
+				// If the relay does not support V2 API, retry with V1 API
+				// we can fallback to V1 API if the status code returned >= 400. There is no harm 
+				// falling back to the V1 API, falling back to the V1 API in the case of any error 
+				// can be beneficial to the proposer to avoid a missed slot. 
+				if resp.StatusCode >= http.StatusBadRequest && url == relay.GetURI(params.PathGetPayloadV2) {
+					log.Warn("relay may not support V2 API, Retrying with V1 API")
 					// retry with v1 api
 					url = relay.GetURI(params.PathGetPayload)
 					versionToUse = GetPayloadV1

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -60,15 +60,15 @@ type payloadResult struct {
 
 // Deprecated: For reference: https://github.com/ethereum/builder-specs/issues/119
 // getPayload requests the payload (execution payload, blobs bundle, etc) from the relays
-func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (*builderApi.VersionedSubmitBlindedBlockResponse, bidResp) {
+func (m *BoostService) getPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (payloadResult, bidResp) {
 	result, bid := m.innerGetPayload(log, signedBlindedBeaconBlockBytes, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion, GetPayloadV1)
-	return result.response, bid
+	return result, bid
 }
 
 // getPayloadV2 submits the signed blinded beacon block to relays for submission without returning the payload and blobs
-func (m *BoostService) getPayloadV2(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (bool, bidResp) {
+func (m *BoostService) getPayloadV2(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string) (payloadResult, bidResp) {
 	result, bid := m.innerGetPayload(log, signedBlindedBeaconBlockBytes, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion, GetPayloadV2)
-	return result.success, bid
+	return result, bid
 }
 
 func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string, version GetPayloadVersion) (payloadResult, bidResp) {
@@ -157,14 +157,17 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry) {
+
+			var versionToUse GetPayloadVersion
 			var url string
 			if version == GetPayloadV1 {
 				url = relay.GetURI(params.PathGetPayload)
+				versionToUse = GetPayloadV1
 			} else {
 				url = relay.GetURI(params.PathGetPayloadV2)
+				versionToUse = GetPayloadV2
 			}
-			log := log.WithField("url", url)
-			log.Debugf("calling getPayload%s", version)
+
 
 			// If the request fails, try again a few times with 100ms between tries
 			resp, err := retry(requestCtx, m.requestMaxRetries, 100*time.Millisecond, func() (*http.Response, error) {
@@ -198,6 +201,11 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 					}).Info("Converted request from SSZ to JSON for relay")
 				}
 
+				log.WithFields(logrus.Fields{
+					"url": url,
+					"version": versionToUse,
+				}).Info("calling getPayload")
+
 				// Make a new request
 				req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, url, bytes.NewReader(requestBytes))
 				if err != nil {
@@ -215,7 +223,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 				statusCode := http.StatusOK
 				endpoint := params.PathGetPayload
-				if version == GetPayloadV2 {
+				if versionToUse == GetPayloadV2 {
 					statusCode = http.StatusAccepted
 					endpoint = params.PathGetPayloadV2
 				}
@@ -225,12 +233,20 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				resp, err := m.httpClientGetPayload.Do(req)
 				RecordRelayLatency(endpoint, relay.String(), float64(time.Since(start).Microseconds()))
 				if err != nil {
-					log.WithError(err).Warnf("error calling getPayload%s on relay", version)
+					log.WithError(err).Warnf("error calling getPayload%s on relay", versionToUse)
 					return nil, err
 				}
 
 				RecordRelayStatusCode(strconv.Itoa(statusCode), endpoint, relay.String())
 				// Check that the response was successful
+
+				if resp.StatusCode == http.StatusNotFound && url == relay.GetURI(params.PathGetPayloadV2) {
+					log.Warn("relay may not support V2 API, Retrying with v1 API")
+					// retry with v1 api
+					url = relay.GetURI(params.PathGetPayload)
+					versionToUse = GetPayloadV1
+					return nil, fmt.Errorf("relay may not support V2 API, Retrying with v1 API")
+				}
 				if resp.StatusCode != statusCode {
 					err = fmt.Errorf("%w: %d", errHTTPErrorResponse, resp.StatusCode)
 					log.WithError(err).Warn("error status code")
@@ -248,7 +264,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 			var result payloadResult
 			result.success = true
 
-			if version == GetPayloadV1 {
+			if versionToUse == GetPayloadV1 {
 				// Get the resp body content
 				respBytes, err := io.ReadAll(resp.Body)
 				if err != nil {

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -71,7 +71,7 @@ func (m *BoostService) getPayloadV2(log *logrus.Entry, signedBlindedBeaconBlockB
 	return result, bid
 }
 
-func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string, version GetPayloadVersion) (payloadResult, bidResp) {
+func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string, versionToUse GetPayloadVersion) (payloadResult, bidResp) {
 	// Get the request's content type
 	parsedProposerContentType, _, err := mime.ParseMediaType(proposerContentType)
 	if err != nil {
@@ -157,14 +157,11 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry) {
-			var versionToUse GetPayloadVersion
 			var url string
-			if version == GetPayloadV1 {
+			if versionToUse == GetPayloadV1 {
 				url = relay.GetURI(params.PathGetPayload)
-				versionToUse = GetPayloadV1
 			} else {
 				url = relay.GetURI(params.PathGetPayloadV2)
-				versionToUse = GetPayloadV2
 			}
 
 			// If the request fails, try again a few times with 100ms between tries

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -157,7 +157,6 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry) {
-
 			var versionToUse GetPayloadVersion
 			var url string
 			if version == GetPayloadV1 {
@@ -167,7 +166,6 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				url = relay.GetURI(params.PathGetPayloadV2)
 				versionToUse = GetPayloadV2
 			}
-
 
 			// If the request fails, try again a few times with 100ms between tries
 			resp, err := retry(requestCtx, m.requestMaxRetries, 100*time.Millisecond, func() (*http.Response, error) {
@@ -202,7 +200,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				}
 
 				log.WithFields(logrus.Fields{
-					"url": url,
+					"url":     url,
 					"version": versionToUse,
 				}).Info("calling getPayload")
 
@@ -245,7 +243,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 					// retry with v1 api
 					url = relay.GetURI(params.PathGetPayload)
 					versionToUse = GetPayloadV1
-					return nil, fmt.Errorf("relay may not support V2 API, Retrying with v1 API")
+					return nil, errRetryWithV1API
 				}
 				if resp.StatusCode != statusCode {
 					err = fmt.Errorf("%w: %d", errHTTPErrorResponse, resp.StatusCode)

--- a/server/service.go
+++ b/server/service.go
@@ -399,7 +399,7 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 	result, originalBid := m.getPayload(log, signedBlindedBlockBytes, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion)
 
 	// If no payload has been received from relay, log loudly about withholding!
-	if result == nil || getPayloadResponseIsEmpty(result) {
+	if result.response == nil || getPayloadResponseIsEmpty(result.response) {
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusBadGateway), params.PathGetPayload)
 		originRelays := types.RelayEntriesToStrings(originalBid.relays)
 		log.WithField("relaysWithBid", strings.Join(originRelays, ", ")).Error("no payload received from relay!")
@@ -425,11 +425,11 @@ func (m *BoostService) handleGetPayload(w http.ResponseWriter, req *http.Request
 	case MediaTypeJSON:
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusOK), params.PathGetPayload)
 		log.Debug("responding with JSON")
-		m.respondGetPayloadJSON(w, result)
+		m.respondGetPayloadJSON(w, result.response)
 	case MediaTypeOctetStream:
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusOK), params.PathGetPayload)
 		log.Debug("responding with SSZ")
-		m.respondGetPayloadSSZ(w, result)
+		m.respondGetPayloadSSZ(w, result.response)
 	default:
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusNotAcceptable), params.PathGetPayload)
 		message := fmt.Sprintf("unsupported media type: %s", proposerPreferredContentType)
@@ -466,10 +466,10 @@ func (m *BoostService) handleGetPayloadV2(w http.ResponseWriter, req *http.Reque
 	}
 
 	// Submit the signed blinded beacon block to relays
-	success, originalBid := m.getPayloadV2(log, signedBlindedBlockBytes, userAgent, proposerContentType, acceptContentType, proposerEthConsensusVersion)
+	result, originalBid := m.getPayloadV2(log, signedBlindedBlockBytes, userAgent, proposerContentType, acceptContentType, proposerEthConsensusVersion)
 
 	// If no relay accepted the submission, log about the failure
-	if !success {
+	if !result.success {
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusBadGateway), params.PathGetPayloadV2)
 		originRelays := types.RelayEntriesToStrings(originalBid.relays)
 		log.WithField("relaysWithBid", strings.Join(originRelays, ", ")).Error("no relay accepted the signed blinded beacon block submission!")

--- a/server/service.go
+++ b/server/service.go
@@ -33,7 +33,7 @@ var (
 	errInvalidPubkey             = errors.New("invalid pubkey")
 	errNoSuccessfulRelayResponse = errors.New("no successful relay response")
 	errServerAlreadyRunning      = errors.New("server already running")
-	errRetryWithV1API            = errors.New("relay may not support V2 API, retrying with v1 API")
+	errRetryWithV1API            = errors.New("relay may not support V2 API, retrying with V1 API")
 )
 
 var (

--- a/server/service.go
+++ b/server/service.go
@@ -33,6 +33,7 @@ var (
 	errInvalidPubkey             = errors.New("invalid pubkey")
 	errNoSuccessfulRelayResponse = errors.New("no successful relay response")
 	errServerAlreadyRunning      = errors.New("server already running")
+	errRetryWithV1API            = errors.New("relay may not support V2 API, retrying with v1 API")
 )
 
 var (

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1251,7 +1251,7 @@ func TestGetPayloadV2(t *testing.T) {
 		backend.relays[0].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			_, err := w.Write([]byte(`{"code":400,"message":"bad request"}`))
-			require.NoError(t, err, "failed to write error response")
+			require.NoError(t, err, "failed to write error response") //nolint:testifylint // if we fail here the test is compromised
 		})
 
 		rr := backend.request(t, http.MethodPost, path, header, payload)
@@ -1280,7 +1280,7 @@ func TestGetPayloadV2(t *testing.T) {
 		backend.relays[0].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, err := w.Write([]byte(`{"code":500,"message":"internal server error"}`))
-			require.NoError(t, err, "failed to write error response")
+			require.NoError(t, err, "failed to write error response") //nolint:testifylint // if we fail here the test is compromised
 		})
 
 		rr := backend.request(t, http.MethodPost, path, header, payload)

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1232,40 +1232,6 @@ func TestGetPayloadV2(t *testing.T) {
 		rr := backend.request(t, http.MethodPost, path, header, payload)
 		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
 	})
-
-	t.Run("Error after max retries are reached", func(t *testing.T) {
-		header := make(http.Header)
-		header.Set(HeaderAccept, MediaTypeJSON)
-		header.Set("Eth-Consensus-Version", "deneb")
-
-		backend := newTestBackend(t, 1, time.Second)
-
-		// Add the bid to the service
-		bid := bidResp{relays: make([]types.RelayEntry, len(backend.relays))}
-		for i, relay := range backend.relays {
-			bid.relays[i] = relay.RelayEntry
-		}
-		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
-
-		count := 0
-		maxRetries := 5
-
-		backend.relays[0].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
-			count++
-			if count > maxRetries {
-				// success response after max retry attempts
-				backend.relays[0].DefaultHandleGetPayloadV2(w)
-			} else {
-				w.WriteHeader(http.StatusInternalServerError)
-				_, err := w.Write([]byte(`{"code":500,"message":"internal server error"}`))
-				require.NoError(t, err, "failed to write error response") //nolint:testifylint // if we fail here the test is compromised
-			}
-		})
-		rr := backend.request(t, http.MethodPost, path, header, payload)
-		require.Equal(t, 5, backend.relays[0].GetRequestCount(path))
-		require.JSONEq(t, `{"code":502,"message":"no successful relay response"}`+"\n", rr.Body.String())
-		require.Equal(t, http.StatusBadGateway, rr.Code, rr.Body.String())
-	})
 }
 
 func TestCheckRelays(t *testing.T) {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1232,6 +1232,64 @@ func TestGetPayloadV2(t *testing.T) {
 		rr := backend.request(t, http.MethodPost, path, header, payload)
 		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
 	})
+
+	t.Run("Retries with V1 API when V2 API is not found", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
+
+		backend := newTestBackend(t, 1, 2*time.Second)
+
+		// Add the bid to the service
+		bid := bidResp{relays: make([]types.RelayEntry, len(backend.relays))}
+		for i, relay := range backend.relays {
+			bid.relays[i] = relay.RelayEntry
+		}
+		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
+
+		// Override V2 handler to return error, V1 handler to succeed
+		backend.relays[0].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte(`{"code":400,"message":"bad request"}`))
+			require.NoError(t, err, "failed to write error response")
+		})
+
+		rr := backend.request(t, http.MethodPost, path, header, payload)
+		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
+
+		// Verify both V2 and V1 endpoints were called
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(params.PathGetPayloadV2))
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(params.PathGetPayload))
+	})
+
+	t.Run("Retries with V1 API when V2 API fails", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
+
+		backend := newTestBackend(t, 1, 2*time.Second)
+
+		// Add the bid to the service
+		bid := bidResp{relays: make([]types.RelayEntry, len(backend.relays))}
+		for i, relay := range backend.relays {
+			bid.relays[i] = relay.RelayEntry
+		}
+		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
+
+		// Override V2 handler to return error, V1 handler to succeed
+		backend.relays[0].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte(`{"code":500,"message":"internal server error"}`))
+			require.NoError(t, err, "failed to write error response")
+		})
+
+		rr := backend.request(t, http.MethodPost, path, header, payload)
+		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
+
+		// Verify both V2 and V1 endpoints were called
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(params.PathGetPayloadV2))
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(params.PathGetPayload))
+	})
 }
 
 func TestCheckRelays(t *testing.T) {


### PR DESCRIPTION
## 📝 Summary

We want to fallback calling the v1 getPayload API if the v2 getPayload API fails. 

https://github.com/ethereum/builder-specs/pull/123 introduced a new v2 getPayload API for the relays. This essentially doesn't return the entire signed beacon block response which can really large with more blobs. 

If in case, relays do not implement this API. The getPayload v2 API will return a 404 not found and the slot will be missed. It would be better to fallback to the v1 API in such a case to avoid a missed slot.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
