### PR TITLE
Prepare for Fulu Release

### DIFF
--- a/config/vars.go
+++ b/config/vars.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is set at build time (must be a var, not a const!)
-	Version = "v1.9"
+	Version = "v1.10"
 
 	// RFC3339Milli is a time format string based on time.RFC3339 but with millisecond precision
 	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"


### PR DESCRIPTION
## 📝 Summary

Bump up version to v1.10 to prepare for Fulu Mainnet release.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
