### PR TITLE
allow background relay requests in getPayloadV2

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -184,6 +184,7 @@ func setupLogging(cmd *cli.Command) error {
 		log.Logger.SetFormatter(&logrus.TextFormatter{
 			FullTimestamp:   true,
 			TimestampFormat: config.RFC3339Milli,
+			ForceColors:     true,
 		})
 	}
 

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -166,6 +166,8 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 			// If the request fails, try again a few times with 100ms between tries
 			resp, err := retry(requestCtx, m.requestMaxRetries, 100*time.Millisecond, func() (*http.Response, error) {
+				log = log.WithField("url", url)
+
 				// Default to the content from the proposer
 				requestContentType := parsedProposerContentType
 				requestBytes := signedBlindedBeaconBlockBytes
@@ -240,6 +242,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				// falling back to the V1 API, falling back to the V1 API in the case of any error
 				// can be beneficial to the proposer to avoid a missed slot.
 				if resp.StatusCode >= http.StatusBadRequest && url == relay.GetURI(params.PathGetPayloadV2) {
+					log.WithError(err).Warn("unexpected status code")
 					log.Warn("relay may not support V2 API, Retrying with V1 API")
 					// retry with v1 api
 					url = relay.GetURI(params.PathGetPayload)
@@ -248,7 +251,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				}
 				if resp.StatusCode != statusCode {
 					err = fmt.Errorf("%w: %d", errHTTPErrorResponse, resp.StatusCode)
-					log.WithError(err).Warn("error status code")
+					log.WithError(err).Warn("unexpected status code")
 					return nil, err
 				}
 

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -154,7 +154,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 	// Create a context with a timeout as configured in the http client
 	requestCtx, requestCtxCancel := context.WithTimeout(context.Background(), m.httpClientGetPayload.Timeout)
 	defer requestCtxCancel()
-	originalVersionToUse := versionToUse
+	originalVersionToUse := version
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry, versionToUse GetPayloadVersion) {

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -199,7 +199,6 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				}
 
 				log.WithFields(logrus.Fields{
-					"url":     url,
 					"version": versionToUse,
 				}).Info("calling getPayload")
 
@@ -304,7 +303,9 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				result.response = response
 			}
 
-			// We have received a valid response, return the first one
+			// We have received a valid response, return the first one.
+			// The other requests will be running in the background to provide redundancy 
+			// in case the relay provider which returned the first request fails to broadcast the block.
 			if received.CompareAndSwap(false, true) {
 				resultCh <- result
 				log.Info("successfully submitted blinded block to relay")

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -236,21 +236,29 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				RecordRelayStatusCode(strconv.Itoa(statusCode), endpoint, relay.String())
 				// Check that the response was successful
 
-				// If the relay does not support V2 API, retry with V1 API
-				// we can fallback to V1 API if the status code returned >= 400. There is no harm
-				// falling back to the V1 API, falling back to the V1 API in the case of any error
-				// can be beneficial to the proposer to avoid a missed slot.
-				if resp.StatusCode >= http.StatusBadRequest && url == relay.GetURI(params.PathGetPayloadV2) {
-					log.WithError(err).Warn("unexpected status code")
-					log.Warn("relay may not support V2 API, Retrying with V1 API")
-					// retry with v1 api
-					url = relay.GetURI(params.PathGetPayload)
-					versionToUse = GetPayloadV1
-					return nil, errRetryWithV1API
-				}
+				// If the response status code doesn't match expected, read error body once
 				if resp.StatusCode != statusCode {
-					err = fmt.Errorf("%w: %d", errHTTPErrorResponse, resp.StatusCode)
-					log.WithError(err).Warn("unexpected status code")
+					errorBody, err := io.ReadAll(resp.Body)
+					if err != nil {
+						log.WithError(err).Warn("error reading error body")
+						return nil, err
+					}
+					errorBodyStr := string(errorBody)
+					log.WithField("errorBody", errorBodyStr).Warnf("unexpected status code %d", resp.StatusCode)
+
+					// If the relay does not support V2 API, retry with V1 API
+					// we can fallback to V1 API if the status code returned >= 400. There is no harm
+					// falling back to the V1 API, falling back to the V1 API in the case of any error
+					// can be beneficial to the proposer to avoid a missed slot.
+					if resp.StatusCode >= http.StatusBadRequest && url == relay.GetURI(params.PathGetPayloadV2) {
+						log.Warn("relay may not support V2 API, Retrying with V1 API")
+						// retry with v1 api
+						url = relay.GetURI(params.PathGetPayload)
+						versionToUse = GetPayloadV1
+						return nil, errRetryWithV1API
+					}
+
+					err = fmt.Errorf("%w: %d: %s", errHTTPErrorResponse, resp.StatusCode, errorBodyStr)
 					return nil, err
 				}
 
@@ -304,7 +312,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 			}
 
 			// We have received a valid response, return the first one.
-			// The other requests will be running in the background to provide redundancy 
+			// The other requests will be running in the background to provide redundancy
 			// in case the relay provider which returned the first request fails to broadcast the block.
 			if received.CompareAndSwap(false, true) {
 				resultCh <- result

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -154,6 +154,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 	// Create a context with a timeout as configured in the http client
 	requestCtx, requestCtxCancel := context.WithTimeout(context.Background(), m.httpClientGetPayload.Timeout)
 	defer requestCtxCancel()
+	originalVersionToUse := versionToUse
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry, versionToUse GetPayloadVersion) {
@@ -301,10 +302,12 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				result.response = response
 			}
 
-			// The payload is valid, cancel the request for others
-			requestCtxCancel()
+			if originalVersionToUse == GetPayloadV1 {
+				// cancel other request only for v1 endpoints
+				requestCtxCancel()
+			}
 
-			// We have received a valid response, cancel other requests
+			// We have received a valid response, return the first one
 			if received.CompareAndSwap(false, true) {
 				resultCh <- result
 				log.Info("successfully submitted blinded block to relay")

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -154,7 +154,6 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 	// Create a context with a timeout as configured in the http client
 	requestCtx, requestCtxCancel := context.WithTimeout(context.Background(), m.httpClientGetPayload.Timeout)
 	defer requestCtxCancel()
-	originalVersionToUse := version
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry, versionToUse GetPayloadVersion) {
@@ -300,11 +299,6 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				}
 
 				result.response = response
-			}
-
-			if originalVersionToUse == GetPayloadV1 {
-				// cancel other request only for v1 endpoints
-				requestCtxCancel()
 			}
 
 			// We have received a valid response, return the first one

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -251,7 +251,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 					// falling back to the V1 API, falling back to the V1 API in the case of any error
 					// can be beneficial to the proposer to avoid a missed slot.
 					if resp.StatusCode >= http.StatusBadRequest && url == relay.GetURI(params.PathGetPayloadV2) {
-						log.Warn("relay may not support V2 API, Retrying with V1 API")
+						log.Warn("relay may not support getPayloadV2 endpoint, retrying with getPayloadV1 endpoint")
 						// retry with v1 api
 						url = relay.GetURI(params.PathGetPayload)
 						versionToUse = GetPayloadV1

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1290,6 +1290,45 @@ func TestGetPayloadV2(t *testing.T) {
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(params.PathGetPayloadV2))
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(params.PathGetPayload))
 	})
+
+	t.Run("V2 requests to all relays continue in background after first 202 response", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set(HeaderAccept, MediaTypeJSON)
+		header.Set("Eth-Consensus-Version", "deneb")
+
+		backend := newTestBackend(t, 3, 5*time.Second)
+
+		bid := bidResp{relays: make([]types.RelayEntry, len(backend.relays))}
+		for i, relay := range backend.relays {
+			bid.relays[i] = relay.RelayEntry
+		}
+		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
+
+		backend.relays[0].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		})
+
+		delay := 200 * time.Millisecond
+		backend.relays[1].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(delay)
+			w.WriteHeader(http.StatusAccepted)
+		})
+
+		backend.relays[2].OverrideHandleGetPayloadV2(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(delay)
+			w.WriteHeader(http.StatusAccepted)
+		})
+
+		startTime := time.Now()
+		rr := backend.request(t, http.MethodPost, path, header, payload)
+		firstResponseTime := time.Since(startTime)
+
+		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
+		require.Less(t, firstResponseTime, delay)
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
+		require.Equal(t, 1, backend.relays[1].GetRequestCount(path))
+		require.Equal(t, 1, backend.relays[2].GetRequestCount(path))
+	})
 }
 
 func TestCheckRelays(t *testing.T) {


### PR DESCRIPTION
## 📝 Summary

This PR allows sending `getPayloadV2` endpoint to all relays by allowing relay requests to continue in the background after receiving the first successful response.

This PR also involves  improving the logging around MEV-Boost:
1. We add color to the logs to improve readability
2. in the GetPayload request handle, we ensure that we log the url and the errorBody upon response if there is an error.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
