### PR TITLE
Fix race condition by capturing version in goroutine

### DIFF
--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -157,6 +157,8 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 	for _, relay := range m.relays {
 		go func(relay types.RelayEntry) {
+			// Capture the version for this specific goroutine to avoid race conditions
+			versionToUse := versionToUse
 			var url string
 			if versionToUse == GetPayloadV1 {
 				url = relay.GetURI(params.PathGetPayload)

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -156,9 +156,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 	defer requestCtxCancel()
 
 	for _, relay := range m.relays {
-		go func(relay types.RelayEntry) {
-			// Capture the version for this specific goroutine to avoid race conditions
-			versionToUse := versionToUse
+		go func(relay types.RelayEntry, versionToUse GetPayloadVersion) {
 			var url string
 			if versionToUse == GetPayloadV1 {
 				url = relay.GetURI(params.PathGetPayload)
@@ -313,7 +311,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 			} else {
 				log.Trace("discarding response, already received a correct response")
 			}
-		}(relay)
+		}(relay, versionToUse)
 	}
 
 	// Wait for the first request to complete

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -71,7 +71,7 @@ func (m *BoostService) getPayloadV2(log *logrus.Entry, signedBlindedBeaconBlockB
 	return result, bid
 }
 
-func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string, versionToUse GetPayloadVersion) (payloadResult, bidResp) {
+func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlockBytes []byte, userAgent, proposerContentType, proposerAcceptContentTypes, proposerEthConsensusVersion string, version GetPayloadVersion) (payloadResult, bidResp) {
 	// Get the request's content type
 	parsedProposerContentType, _, err := mime.ParseMediaType(proposerContentType)
 	if err != nil {
@@ -311,7 +311,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 			} else {
 				log.Trace("discarding response, already received a correct response")
 			}
-		}(relay, versionToUse)
+		}(relay, version)
 	}
 
 	// Wait for the first request to complete


### PR DESCRIPTION
The problem is related to a **race condition** when using the `versionToUse` variable in concurrent goroutines:

## Problem Description

At line **246** (`versionToUse = GetPayloadV1`), a local variable `versionToUse` is modified, which is captured by the closure of all running goroutines (lines 159-314). This leads to the following issue:

1. **N goroutines are launched** for N relays with `versionToUse == GetPayloadV2`
2. **Relay A** doesn't support V2 API → returns an error (StatusCode >= 400)
3. **Goroutine A** modifies the shared variable to `versionToUse = GetPayloadV1` (line 246)
4. **Relay B** supports V2 API → returns a valid response with `StatusCode == 202 (Accepted)`
5. **Goroutine B** tries to process the response, but due to the variable change, enters the condition `if versionToUse == GetPayloadV1` (line 266)
6. **Parsing of a valid V2 response** occurs as V1, leading to a decoding error

## Technical Details

All goroutines share a single `versionToUse` variable captured through closure. When one goroutine modifies its value (line 246), it **immediately affects the processing logic in other goroutines** (lines 266-302), which may be at different execution stages.

## Consequences

- Valid V2 responses will be parsed as V1
- A decoding error will occur (line 288)
- Valid payload will be rejected
- Potentially may lead to a missed slot