### PR TITLE
add color flag for text log

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Usage of mev-boost:
   -json
         log in JSON format instead of text
   -color
-        enable colored output for text log format
+        enable colored output for text log format; has no effect if JSON logging is enabled via -json
   -log-no-version
         disables adding the version to every log entry
   -log-service string

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Usage of mev-boost:
         use Hoodi
   -json
         log in JSON format instead of text
+  -color
+        enable colored output for text log format
   -log-no-version
         disables adding the version to every log entry
   -log-service string

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -16,6 +16,7 @@ var flags = []cli.Flag{
 	versionFlag,
 	// logging
 	jsonFlag,
+	colorFlag,
 	debugFlag,
 	logLevelFlag,
 	logServiceFlag,
@@ -61,6 +62,12 @@ var (
 		Name:     "json",
 		Sources:  cli.EnvVars("LOG_JSON"),
 		Usage:    "log in JSON format instead of text",
+		Category: LoggingCategory,
+	}
+	colorFlag = &cli.BoolFlag{
+		Name:     "color",
+		Sources:  cli.EnvVars("LOG_COLOR"),
+		Usage:    "enable colored output for text log format",
 		Category: LoggingCategory,
 	}
 	debugFlag = &cli.BoolFlag{

--- a/cli/main.go
+++ b/cli/main.go
@@ -184,7 +184,7 @@ func setupLogging(cmd *cli.Command) error {
 		log.Logger.SetFormatter(&logrus.TextFormatter{
 			FullTimestamp:   true,
 			TimestampFormat: config.RFC3339Milli,
-			ForceColors:     true,
+			ForceColors:     cmd.Bool(colorFlag.Name),
 		})
 	}
 


### PR DESCRIPTION
## 📝 Summary

Introduces an optional `color` flag for text log fmt
Closes #867

## ⛱ Motivation and Context

Previously we were enforcing color for text logs, this change makes it configurable, so users can choose depending on their preference.  

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
