### PR TITLE
update latency metric from microseconds to milliseconds

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -69,6 +69,7 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 		"msIntoSlot":  msIntoSlot,
 	}).Infof("getHeader request start - %d milliseconds into slot %d", msIntoSlot, slot)
 
+	RecordMsIntoSlot(params.PathGetHeader, float64(msIntoSlot))
 	var (
 		mu           sync.Mutex
 		wg           sync.WaitGroup
@@ -321,7 +322,7 @@ func (m *BoostService) sendGetHeaderRequest(
 	start := time.Now()
 
 	resp, err := m.httpClientGetHeader.Do(req)
-	RecordRelayLatency(params.PathGetHeader, relay.URL.Hostname(), float64(time.Since(start).Microseconds()))
+	RecordRelayLatency(params.PathGetHeader, relay.URL.Hostname(), float64(time.Since(start).Milliseconds()))
 	if err != nil {
 		log.WithError(err).Warn("error calling getHeader on relay")
 		return nil, ""

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -132,6 +132,8 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 		"msIntoSlot":  msIntoSlot,
 	}).Infof("submitBlindedBlock request start - %d milliseconds into slot %d", msIntoSlot, slot)
 
+	// storing via function to not run into too many decision paths
+	recordGetPayloadMsIntoSlot(version, msIntoSlot)
 	// Get the bid!
 	m.bidsLock.Lock()
 	originalBid := m.bids[bidKey(slot, blockHash)]
@@ -231,7 +233,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				innerLog.Debug("submitting signed blinded block")
 				start := time.Now()
 				resp, err := m.httpClientGetPayload.Do(req)
-				RecordRelayLatency(endpoint, relay.URL.Hostname(), float64(time.Since(start).Microseconds()))
+				RecordRelayLatency(endpoint, relay.URL.Hostname(), float64(time.Since(start).Milliseconds()))
 				if err != nil {
 					innerLog.WithError(err).Warnf("error calling getPayload%s on relay", versionToUse)
 					return nil, err
@@ -695,6 +697,14 @@ func (m *BoostService) respondGetPayloadSSZ(w http.ResponseWriter, result *build
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Other Functions
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+func recordGetPayloadMsIntoSlot(version GetPayloadVersion, msIntoSlot uint64) {
+	endpoint := params.PathGetPayload
+	if version == GetPayloadV2 {
+		endpoint = params.PathGetPayloadV2
+	}
+	RecordMsIntoSlot(endpoint, float64(msIntoSlot))
+}
 
 // bidKey makes a map key for a specific bid
 func bidKey(slot phase0.Slot, blockHash phase0.Hash32) string {

--- a/server/register_validator.go
+++ b/server/register_validator.go
@@ -53,7 +53,7 @@ func (m *BoostService) registerValidator(log *logrus.Entry, regBytes []byte, hea
 			// Send the request
 			start := time.Now()
 			resp, err := m.httpClientRegVal.Do(req)
-			RecordRelayLatency(params.PathRegisterValidator, relay.URL.Hostname(), float64(time.Since(start).Microseconds()))
+			RecordRelayLatency(params.PathRegisterValidator, relay.URL.Hostname(), float64(time.Since(start).Milliseconds()))
 			if err != nil {
 				log.WithError(err).Warn("error calling registerValidator on relay")
 				respErrCh <- err

--- a/server/service.go
+++ b/server/service.go
@@ -523,7 +523,7 @@ func (m *BoostService) CheckRelays() int {
 
 			start := time.Now()
 			code, err := SendHTTPRequest(context.Background(), m.httpClientGetHeader, http.MethodGet, url, "", nil, nil, nil)
-			RecordRelayLatency(params.PathStatus, relay.URL.Hostname(), float64(time.Since(start).Microseconds()))
+			RecordRelayLatency(params.PathStatus, relay.URL.Hostname(), float64(time.Since(start).Milliseconds()))
 			if err != nil {
 				log.WithError(err).Error("relay status error - request failed")
 				return


### PR DESCRIPTION
## 📝 Summary

1. Updates `RecordRelayLatency` metric from microseconds to milliseconds
2. Records metrics for ms into slot for `get_header` and `get_payload` (v1, v2) requests

## ⛱ Motivation and Context

Having latency values in microseconds causes in a lot of unreadable values in the metrics, therefore we have decided to store in milliseconds

## 📚 References

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
