### PR TITLE
add black list control

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -123,6 +123,11 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 
 	// Request a bid from each relay
 	for _, relayConfig := range relayConfigs {
+		if m.relayIsBlacklisted(relayConfig.RelayEntry) {
+			log.WithField("relay", relayConfig.RelayEntry.String()).Warn("skipping temporarily blacklisted relay")
+			continue
+		}
+
 		wg.Add(1)
 		go func(relayConfig types.RelayConfig) {
 			relay := relayConfig.RelayEntry

--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"slices"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -56,6 +55,7 @@ const (
 type payloadResult struct {
 	success  bool
 	response *builderApi.VersionedSubmitBlindedBlockResponse
+	relay    types.RelayEntry
 }
 
 // Deprecated: For reference: https://github.com/ethereum/builder-specs/issues/119
@@ -163,6 +163,9 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 	for _, relayConfig := range m.relayConfigs {
 		go func(relay types.RelayEntry, versionToUse GetPayloadVersion) {
+			matchedRelay, relayShouldDeliver := findRelayForPayload(relay, originalBid.relays)
+			delivered := false
+
 			var url string
 			if versionToUse == GetPayloadV1 {
 				url = relay.GetURI(params.PathGetPayload)
@@ -170,6 +173,18 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				url = relay.GetURI(params.PathGetPayloadV2)
 			}
 			innerLog := log.WithField("url", url)
+
+			defer func() {
+				if !relayShouldDeliver {
+					return
+				}
+				if delivered {
+					m.clearRelayFailure(relay)
+					return
+				}
+				innerLog.Warn("temporarily blacklisting relay after payload withholding")
+				m.markRelayFailure(relay)
+			}()
 
 			// If the request fails, try again a few times with 100ms between tries
 			resp, err := retry(requestCtx, m.requestMaxRetries, 100*time.Millisecond, func() (*http.Response, error) {
@@ -179,13 +194,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				requestBytes := signedBlindedBeaconBlockBytes
 
 				// Check if the relay supports SSZ
-				relaySupportsSSZ := false
-				for _, originalBidRelay := range originalBid.relays {
-					if relay.URL == originalBidRelay.URL {
-						relaySupportsSSZ = originalBidRelay.SupportsSSZ
-						break
-					}
-				}
+				relaySupportsSSZ := matchedRelay.SupportsSSZ
 				innerLog.WithField("relaySupportsSSZ", relaySupportsSSZ).Debug("encoding preference")
 
 				// If the relay provided the bid in JSON or did not provide a bid for this payload,
@@ -199,7 +208,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 						return nil, err
 					}
 					innerLog.WithFields(logrus.Fields{
-						"relayProvidedBid": slices.Contains(originalBid.relays, relay),
+						"relayProvidedBid": relayShouldDeliver,
 						"conversionTime":   time.Since(startTime),
 					}).Info("Converted request from SSZ to JSON for relay")
 				}
@@ -278,6 +287,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 			var result payloadResult
 			result.success = true
+			result.relay = relay
 
 			if versionToUse == GetPayloadV1 {
 				// Get the resp body content
@@ -316,6 +326,8 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 
 				result.response = response
 			}
+
+			delivered = true
 
 			// We have received a valid response, return the first one.
 			// The other requests will be running in the background to provide redundancy
@@ -709,6 +721,22 @@ func recordGetPayloadMsIntoSlot(version GetPayloadVersion, msIntoSlot uint64) {
 // bidKey makes a map key for a specific bid
 func bidKey(slot phase0.Slot, blockHash phase0.Hash32) string {
 	return fmt.Sprintf("%v%v", slot, blockHash)
+}
+
+func findRelayForPayload(relay types.RelayEntry, relays []types.RelayEntry) (types.RelayEntry, bool) {
+	for _, candidate := range relays {
+		if relayEntriesEqual(relay, candidate) {
+			return candidate, true
+		}
+	}
+	return types.RelayEntry{}, false
+}
+
+func relayEntriesEqual(a, b types.RelayEntry) bool {
+	if a.URL != nil && b.URL != nil {
+		return a.URL.String() == b.URL.String()
+	}
+	return a.PublicKey == b.PublicKey
 }
 
 // retry executes the provided function until it succeeds, the context is done, or

--- a/server/service.go
+++ b/server/service.go
@@ -41,6 +41,8 @@ var (
 	nilResponse = struct{}{}
 )
 
+const relayBlacklistDuration = 30 * time.Second
+
 type httpErrorResp struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
@@ -100,6 +102,9 @@ type BoostService struct {
 	relayConfigsLock sync.RWMutex
 
 	metricsAddr string
+
+	relayBlacklist     map[string]time.Time
+	relayBlacklistLock sync.Mutex
 }
 
 // NewBoostService created a new BoostService
@@ -140,6 +145,7 @@ func NewBoostService(opts BoostServiceOpts) (*BoostService, error) {
 		requestMaxRetries:  opts.RequestMaxRetries,
 		timeoutGetHeaderMs: opts.TimeoutGetHeaderMs,
 		lateInSlotTimeMs:   opts.LateInSlotTimeMs,
+		relayBlacklist:     make(map[string]time.Time),
 	}, nil
 }
 
@@ -175,6 +181,48 @@ func (m *BoostService) getRouter() http.Handler {
 	r.Use(mux.CORSMethodMiddleware(r))
 	loggedRouter := httplogger.LoggingMiddlewareLogrus(m.log, r)
 	return loggedRouter
+}
+
+func (m *BoostService) relayIsBlacklisted(relay types.RelayEntry) bool {
+	if relay.URL == nil {
+		return false
+	}
+
+	key := relay.URL.String()
+	m.relayBlacklistLock.Lock()
+	defer m.relayBlacklistLock.Unlock()
+
+	lastFailure, ok := m.relayBlacklist[key]
+	if !ok {
+		return false
+	}
+
+	if time.Since(lastFailure) > relayBlacklistDuration {
+		delete(m.relayBlacklist, key)
+		return false
+	}
+
+	return true
+}
+
+func (m *BoostService) markRelayFailure(relay types.RelayEntry) {
+	if relay.URL == nil {
+		return
+	}
+
+	m.relayBlacklistLock.Lock()
+	m.relayBlacklist[relay.URL.String()] = time.Now()
+	m.relayBlacklistLock.Unlock()
+}
+
+func (m *BoostService) clearRelayFailure(relay types.RelayEntry) {
+	if relay.URL == nil {
+		return
+	}
+
+	m.relayBlacklistLock.Lock()
+	delete(m.relayBlacklist, relay.URL.String())
+	m.relayBlacklistLock.Unlock()
 }
 
 // StartHTTPServer starts the HTTP server for this boost service instance


### PR DESCRIPTION
# Potential Risk from Missing Relay Blacklisting Mechanism

## Problem Context

Currently, during `getHeader` mev-boost only keeps the **highest-value** builder bid and records the set of relays that supplied it. During `getPayload` it fans out payload requests to all relays with a default timeout of `--request-timeout-getpayload=4000ms`. If none of the relays deliver the payload, mev-boost responds to the beacon node with HTTP 502 (core handling in `server/service.go:419-429`), forcing the validator to fall back to the local execution client. The fan-out logic is in `server/get_payload.go:152-334`.

## Risk Description

- **No blacklisting**: Even if a relay repeatedly advertises high-value bids but refuses to deliver during `getPayload`, mev-boost never disables it automatically and will continue to select its bids in later slots.
- **Slot time waste**: When the winning relay withholds until timeout, the validator burns ~4 seconds waiting and still has to fall back to the local execution client, making that slot’s builder flow useless and reducing rewards.
- **DoS vector**: An attacker can run a relay that always posts top bids yet never hands over payloads, causing many validators to waste several slots, especially when operators share similar relay lists.

## Suggested Directions

1. Introduce penalties or blacklisting, e.g., disable or deprioritize a relay after it withholds/times out a given number of times.
2. Persist failure counters on top of existing health checks/metrics so external monitoring or CLI tools can warn operators automatically.
3. Consider keeping a secondary bid (second-highest) from `getHeader` to fall back to when all winning relays fail, reducing slot waste.

These improvements would mitigate the impact of malicious or unstable relays on validator rewards and shrink the 4-second delay + MEV loss caused by a single faulty relay.
