### PR TITLE
ci: add binary testing to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,6 +89,26 @@ jobs:
             dist/mev-boost*.tar.gz
             dist/mev-boost*.txt
 
+  test-binaries:
+    name: Test Release Binaries
+    needs: build-all
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Make directories
+        run: |
+          mkdir -p ./build
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: mev-boost-build
+          path: ./build
+      - name: Test Linux AMD64 binary
+        run: |
+          cd ./build
+          tar -xf mev-boost_*_linux_amd64.tar.gz
+          chmod +x mev-boost
+          ./mev-boost -version
+
   release:
     name: Prepare Github Release
     needs: build-all


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Add a test job to the release workflow that verifies built binaries work correctly before publishing.

Changes:
- Add `test-binaries` job that runs after `build-all`
- Tests Linux AMD64 binary on Ubuntu 20.04
- Runs `mev-boost -version` to verify the binary executes successfully

This catches potential issues with release binaries before they're published to GitHub releases.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Issue to address: https://github.com/flashbots/mev-boost/issues/475

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
