### PR TITLE
server: clarify log when no acceptable bid selected

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -333,7 +333,7 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 
 	// Bail if none of the relays returned a bid
 	if result.response.IsEmpty() {
-		log.Info("no bid received")
+		log.Info("no acceptable bid received")
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusNoContent), params.PathGetHeader)
 		w.WriteHeader(http.StatusNoContent)
 		return


### PR DESCRIPTION
Fixes #869.

When relays return bids but none are accepted, the current info log can say "no bid received", which is misleading. This changes the log message to distinguish "no acceptable bid selected" vs truly receiving no bids.

Tests: `go test ./...`