### PR TITLE
config: derive version from Go module build info

### DIFF
--- a/config/vars.go
+++ b/config/vars.go
@@ -7,7 +7,11 @@ import (
 )
 
 var (
-	// Version is set at build time (must be a var, not a const!)
+	// Version is set at build time (must be a var, not a const!).
+	//
+	// When installed via `go install ...@<version>`, ldflags are not applied, but Go
+	// still embeds the module version in build metadata. We use that as a fallback
+	// so `mev-boost --version` remains meaningful.
 	Version = "dev"
 
 	// RFC3339Milli is a time format string based on time.RFC3339 but with millisecond precision

--- a/config/version.go
+++ b/config/version.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"runtime/debug"
+)
+
+func versionFromBuildInfo(current string, info *debug.BuildInfo) string {
+	if current != "dev" || info == nil {
+		return current
+	}
+	// For `go install module@version`, this is typically a semver tag like
+	// "v1.11.0". For local builds, it is usually "(devel)".
+	if info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return current
+	}
+	return info.Main.Version
+}
+
+func init() {
+	if Version != "dev" {
+		return
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		Version = versionFromBuildInfo(Version, info)
+	}
+}

--- a/config/version_test.go
+++ b/config/version_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestVersionFromBuildInfo(t *testing.T) {
+	bi := &debug.BuildInfo{Main: debug.Module{Version: "v1.11.0"}}
+	if got := versionFromBuildInfo("dev", bi); got != "v1.11.0" {
+		t.Fatalf("expected v1.11.0, got %q", got)
+	}
+
+	biDevel := &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}
+	if got := versionFromBuildInfo("dev", biDevel); got != "dev" {
+		t.Fatalf("expected dev for (devel), got %q", got)
+	}
+
+	if got := versionFromBuildInfo("v9.9.9", bi); got != "v9.9.9" {
+		t.Fatalf("expected to keep non-dev version, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #889.

When mev-boost is installed via `go install ...@latest`, the version string can be empty/unknown unless ldflags are provided. This change derives Version from Go build info / module metadata as a fallback.

Tests: `go test ./...`