### PR TITLE
server: track bids received to clarify empty response logs

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -158,7 +158,7 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 	wg.Wait()
 
 	var (
-		result = bidResp{}
+		result = bidResp{bidsReceived: len(relayBids)}
 		relays = make(map[BlockHashHex][]types.RelayEntry)
 	)
 

--- a/server/service.go
+++ b/server/service.go
@@ -334,9 +334,13 @@ func (m *BoostService) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	// Bail if none of the relays returned a bid
+	// Bail if none of the relays returned an acceptable bid
 	if result.response.IsEmpty() {
-		log.Info("no bid received")
+		if result.bidsReceived > 0 {
+			log.WithField("bidsReceived", result.bidsReceived).Info("no acceptable bid received")
+		} else {
+			log.Info("no bid received")
+		}
 		IncrementBeaconNodeStatus(strconv.Itoa(http.StatusNoContent), params.PathGetHeader)
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -743,6 +743,46 @@ func TestGetHeaderBids(t *testing.T) {
 		require.Equal(t, http.StatusNoContent, rr.Code)
 	})
 
+	t.Run("Bid below min-bid tracks bidsReceived", func(t *testing.T) {
+		backend := newTestBackend(t, 1, time.Second)
+		backend.boost.genesisTime = uint64(time.Now().Unix()) - 24
+
+		// Relay returns a bid below min-bid (12344 < 12345)
+		backend.relays[0].GetHeaderResponse = backend.relays[0].MakeGetHeaderResponse(
+			12344,
+			"0xa28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
+			spec.DataVersionDeneb,
+		)
+
+		log := backend.boost.log.WithField("method", "getHeader")
+		result, err := backend.boost.getHeader(log, 2, pubkey.String(), hash.String(), "", "application/json", 0)
+		require.NoError(t, err)
+
+		// Response should be empty (bid was below min-bid)
+		require.True(t, result.response.IsEmpty())
+		// But bidsReceived should reflect that a bid was received
+		require.Equal(t, 1, result.bidsReceived)
+	})
+
+	t.Run("No relay response tracks zero bidsReceived", func(t *testing.T) {
+		backend := newTestBackend(t, 1, time.Second)
+		backend.boost.genesisTime = uint64(time.Now().Unix()) - 24
+
+		// Relay returns no content (no bid available)
+		backend.relays[0].OverrideHandleGetHeader(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+
+		log := backend.boost.log.WithField("method", "getHeader")
+		result, err := backend.boost.getHeader(log, 2, pubkey.String(), hash.String(), "", "application/json", 0)
+		require.NoError(t, err)
+
+		require.True(t, result.response.IsEmpty())
+		require.Equal(t, 0, result.bidsReceived)
+	})
+
 	t.Run("Allow bids which meet minimum bid cutoff", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)

--- a/server/utils.go
+++ b/server/utils.go
@@ -120,10 +120,11 @@ func DecodeJSON(r io.Reader, dst any) error {
 
 // bidResp are entries in the bids cache
 type bidResp struct {
-	t        time.Time
-	response builderSpec.VersionedSignedBuilderBid
-	bidInfo  bidInfo
-	relays   []types.RelayEntry
+	t            time.Time
+	response     builderSpec.VersionedSignedBuilderBid
+	bidInfo      bidInfo
+	relays       []types.RelayEntry
+	bidsReceived int // number of bids received from relays (including those filtered out)
 }
 
 // bidInfo is used to store bid response fields for logging and validation


### PR DESCRIPTION
## 📝 Summary

When all relay bids are filtered (e.g. below min-bid), the info log says
"no bid received" — but bids were received, they just weren't acceptable.
This tracks the count of bids returned by relays in `bidResp` and uses it
to distinguish between genuinely receiving nothing vs filtering everything out.

- `bidsReceived` set from `len(relayBids)` after relay goroutines complete
- Log says `"no acceptable bid received" bidsReceived=N` when bids were filtered
- Log says `"no bid received"` when relays truly returned nothing
- Two new subtests in `TestGetHeaderBids` covering both cases

## ⛱ Motivation and Context

Fixes #869. Also addresses #489.

Running at default (info) log level, the only signal a validator gets when
bids exist but fall below min-bid is "no bid received". The debug-level
"bid received" and "ignoring bid below min-bid value" logs don't show up
unless you explicitly lower the level. This has confused operators debugging
why blocks were built locally.

## 📚 References

- #869
- #489

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`

Note: `make test-race` times out on `develop` (without this PR's changes)
due to `TestGetPayload/"A relay which does not provide the bid gets a JSON
request"` hanging under the race detector. All tests prior to that pass,
including the new tests added here.