### PR TITLE
fix JSON log marshaling error in registerValidator

### DIFF
--- a/server/register_validator.go
+++ b/server/register_validator.go
@@ -47,9 +47,7 @@ func (m *BoostService) registerValidator(log *logrus.Entry, regBytes []byte, hea
 				req.Header[key] = values
 			}
 
-			log.WithFields(logrus.Fields{
-				"request": req,
-			}).Debug("sending the registerValidator request")
+			log.Debug("sending the registerValidator request")
 
 			// Send the request
 			start := time.Now()


### PR DESCRIPTION
## Summary

- Remove `*http.Request` from logrus fields in `registerValidator` debug log
- The `http.Request.GetBody` field (`func() (io.ReadCloser, error)`) causes `json.Marshal` to fail when running with `-json` log formatting, printing `Failed to obtain reader` to stderr and silently dropping the log entry
- The relay `url` is already present on the logger context (set at line 35), so no useful information is lost

Closes #894