### PR TITLE
fix: replace *http.Request in log field with JSON-safe fields

### DIFF
--- a/server/register_validator.go
+++ b/server/register_validator.go
@@ -48,7 +48,9 @@ func (m *BoostService) registerValidator(log *logrus.Entry, regBytes []byte, hea
 			}
 
 			log.WithFields(logrus.Fields{
-				"request": req,
+				"method":      req.Method,
+				"url":         req.URL.String(),
+				"contentType": req.Header.Get("Content-Type"),
 			}).Debug("sending the registerValidator request")
 
 			// Send the request


### PR DESCRIPTION
## Change Description

Replace raw `*http.Request` struct in logrus field with individual JSON-serializable fields (`method`, `url`, `contentType`).

`*http.Request` contains `GetBody func() (io.ReadCloser, error)` which `encoding/json` cannot marshal. When mev-boost runs with `-json` flag, logrus `JSONFormatter` fails to serialize the field and **silently drops the log entry**.

## Root Cause

`server/register_validator.go:51` passed the full request struct:
```go
log.WithFields(logrus.Fields{
    "request": req,  // contains func() — breaks json.Marshal
}).Debug(...)
```

## Fix

Extract the useful fields instead:
```go
log.WithFields(logrus.Fields{
    "method":      req.Method,
    "url":         req.URL.String(),
    "contentType": req.Header.Get("Content-Type"),
}).Debug(...)
```

Fixes #894.

## Testing

- `go build ./...` — passes
- `go test ./server/...` — all pass