### PR TITLE
Restore relay url logging for best bid message

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -164,7 +164,7 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 
 	// process the bids and select the one with the best value
 	for _, rb := range relayBids {
-		m.processBid(log, rb.relay, rb.bid, rb.contentType, parentHashHex, &result, relays, slot)
+		m.processBid(log, rb.relay, rb.bid, rb.contentType, parentHashHex, &result, pubkey, relays, slot)
 	}
 
 	// Set the winning relays before returning
@@ -387,10 +387,11 @@ func (m *BoostService) processBid(
 	respContentType string,
 	parentHashHex string,
 	result *bidResp,
+	pubkey string,
 	relays map[BlockHashHex][]types.RelayEntry,
 	slot phase0.Slot,
 ) {
-	log = log.WithField("url", relay.URL.String())
+	log = log.WithField("url", relay.GetURI(fmt.Sprintf("/eth/v1/builder/header/%d/%s/%s", slot, parentHashHex, pubkey)))
 
 	// Getting the bid info will check if there are missing fields in the response
 	bidInfo, err := parseBidInfo(bid)

--- a/server/get_header.go
+++ b/server/get_header.go
@@ -390,6 +390,8 @@ func (m *BoostService) processBid(
 	relays map[BlockHashHex][]types.RelayEntry,
 	slot phase0.Slot,
 ) {
+	log = log.WithField("url", relay.URL.String())
+
 	// Getting the bid info will check if there are missing fields in the response
 	bidInfo, err := parseBidInfo(bid)
 	if err != nil {


### PR DESCRIPTION
## 📝 Summary

In 1.11 url attribute has been removed for `bid received` messages which makes it difficult to trace the received bids per slot. Please help to get it merged to restore this attribute in the logs.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
