### PR TITLE
check for underflow

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -192,17 +192,15 @@ func (m *BoostService) handleTimingGamesGetHeader(
 	relay := relayConfig.RelayEntry
 
 	// wait til target time is configured
-	if relayConfig.TargetFirstRequestMs > 0 {
+	if relayConfig.TargetFirstRequestMs > msIntoSlot {
 		delayMs := relayConfig.TargetFirstRequestMs - msIntoSlot
-		if delayMs > 0 {
-			log.WithFields(logrus.Fields{
-				"targetMs":   relayConfig.TargetFirstRequestMs,
-				"msIntoSlot": msIntoSlot,
-				"delayMs":    delayMs,
-			}).Debug("waiting to send header request via timing games")
-			timeoutLeftMs -= delayMs
-			time.Sleep(time.Duration(delayMs) * time.Millisecond)
-		}
+		log.WithFields(logrus.Fields{
+			"targetMs":   relayConfig.TargetFirstRequestMs,
+			"msIntoSlot": msIntoSlot,
+			"delayMs":    delayMs,
+		}).Debug("waiting to send header request via timing games")
+		timeoutLeftMs -= delayMs
+		time.Sleep(time.Duration(delayMs) * time.Millisecond)
 	}
 
 	if relayConfig.FrequencyGetHeaderMs == 0 {


### PR DESCRIPTION
## 📝 Summary

Fix uint64 underflow in timing games target delay. Adds a guard to `TargetFirstRequestMs > msIntoSlot` which makes the subtraction safe .

## ⛱ Motivation and Context

This bug was reported by an external contributor. Thanks to them for reporting it.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
