### PR TITLE
Select highest-value bid in timing games, not most recent

### DIFF
--- a/docs/timing-games.md
+++ b/docs/timing-games.md
@@ -77,7 +77,7 @@ sequenceDiagram
 
     Note right of MB: max_timeout Reached or<br/>Replies Finished
 
-    Note right of MB: 1. Select best from Relay:<br/>Bid C (Latest Received)
+    Note right of MB: 1. Select best from Relay:<br/>Bid C (Highest Value)
 
     Note right of MB: 2. Compare with other relays<br/>(Highest Value Wins)
 
@@ -93,4 +93,4 @@ sequenceDiagram
 
 3. **Delay multiple subsequent requests**: With timing games enabled, if `frequency_get_header_ms` is set, mev-boost sends multiple requests at intervals of `frequency_get_header_ms` until the budget is exhausted.
 
-4. **Best Bid Selection**: From all responses received, mev-boost selects the most recently received bid from each relay, then compares across relays to return the highest value bid.
+4. **Best Bid Selection**: From all responses received, mev-boost selects the highest-value bid from each relay (ties broken by recency), then compares across relays to return the highest value bid overall.

--- a/server/get_header.go
+++ b/server/get_header.go
@@ -22,6 +22,7 @@ import (
 	"github.com/flashbots/mev-boost/server/params"
 	"github.com/flashbots/mev-boost/server/types"
 	"github.com/google/uuid"
+	"github.com/holiman/uint256"
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,6 +35,7 @@ type relayBid struct {
 type bidResult struct {
 	bid         *builderSpec.VersionedSignedBuilderBid
 	contentType string
+	value       *uint256.Int
 	timestamp   time.Time
 }
 
@@ -227,10 +229,16 @@ func (m *BoostService) handleTimingGamesGetHeader(
 		defer wg.Done()
 		bid, contentType := m.sendGetHeaderRequest(log, relay, url, slotUID, userAgent, proposerAcceptContentTypes, timeoutMs)
 		if bid != nil {
+			info, err := parseBidInfo(bid)
+			if err != nil {
+				log.WithError(err).Warn("error parsing bid info via timing games")
+				return
+			}
 			mu.Lock()
 			bidResults = append(bidResults, bidResult{
 				bid:         bid,
 				contentType: contentType,
+				value:       info.value,
 				timestamp:   time.Now(),
 			})
 			mu.Unlock()
@@ -272,21 +280,26 @@ loop:
 	}
 
 	var (
-		latestBid         *builderSpec.VersionedSignedBuilderBid
-		latestContentType string
-		latestTime        time.Time
+		bestBid         *builderSpec.VersionedSignedBuilderBid
+		bestContentType string
+		bestValue       *uint256.Int
+		bestTime        time.Time
 	)
-	// select only the bid which was most recently received and return it
+	// select the most profitable bid received across all polls of this relay.
+	// picking by recency alone (instead of value) would let a later, lower bid
+	// displace an earlier, higher one due to nothing more than network jitter.
 	log.WithField("totalBids", len(bidResults)).Debug("received headers from relay via timing games")
 
 	for _, br := range bidResults {
-		if latestBid == nil || br.timestamp.After(latestTime) {
-			latestBid = br.bid
-			latestContentType = br.contentType
-			latestTime = br.timestamp
+		if bestBid == nil || br.value.Cmp(bestValue) > 0 ||
+			(br.value.Cmp(bestValue) == 0 && br.timestamp.After(bestTime)) {
+			bestBid = br.bid
+			bestContentType = br.contentType
+			bestValue = br.value
+			bestTime = br.timestamp
 		}
 	}
-	return latestBid, latestContentType
+	return bestBid, bestContentType
 }
 
 // sendGetHeaderRequest sends a single getHeader request to a relay and returns the bid and content type

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -909,6 +909,51 @@ func TestGetHeaderTimingGames(t *testing.T) {
 		require.Equal(t, uint256.NewInt(12350), value)
 	})
 
+	t.Run("Timing games keeps highest bid even if a later poll returns a lower one", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set(HeaderAccept, MediaTypeJSON)
+
+		backend := newTestBackend(t, 1, time.Second)
+		backend.boost.genesisTime = uint64(time.Now().Unix()) - 36
+
+		backend.boost.relayConfigs[0].EnableTimingGames = true
+		backend.boost.relayConfigs[0].TargetFirstRequestMs = 0
+		backend.boost.relayConfigs[0].FrequencyGetHeaderMs = 30
+
+		// simulate a builder whose bid value goes up and then drops on the
+		// last poll, e.g. due to network jitter or a re-issued lower bid
+		values := []uint64{12345, 99999, 12345}
+		var callCount int
+		backend.relays[0].OverrideHandleGetHeader(func(w http.ResponseWriter, _ *http.Request) {
+			idx := callCount
+			if idx >= len(values) {
+				idx = len(values) - 1
+			}
+			callCount++
+			response := backend.relays[0].MakeGetHeaderResponse(
+				values[idx],
+				"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+				"0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7",
+				"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249",
+				spec.DataVersionDeneb,
+			)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		})
+
+		rr := backend.request(t, http.MethodGet, path, header, nil)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+		resp := new(builderSpec.VersionedSignedBuilderBid)
+		err := json.Unmarshal(rr.Body.Bytes(), resp)
+		require.NoError(t, err)
+		value, err := resp.Value()
+		require.NoError(t, err)
+		// the highest bid (99999) must win, not the one from the last poll (12345)
+		require.Equal(t, uint256.NewInt(99999), value)
+	})
+
 	t.Run("Timing games with SSZ encoding", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderEthConsensusVersion, "deneb")


### PR DESCRIPTION
## Summary

When timing games are enabled for a relay, `handleTimingGamesGetHeader` sends multiple `getHeader` requests over the course of the slot and picks the bid to use. Currently it picks the most recently received bid from that relay. This PR changes it to pick the highest-value bid received from that relay, with recency only used as a tiebreaker for equal values.

## Motivation and Context

The relay's current best bid is not guaranteed to be monotonically increasing across polls within the same slot. A builder can cancel a previously leading bid, or a different builder can briefly be in the lead between polls. If the last poll happens to return a lower value than an earlier one, mev-boost currently discards the higher bid it already received and signed for, even though nothing requires that.

This gets more costly as bidding margins compress, see https://collective.flashbots.net/t/4734: median winning bid duration at Ultrasound dropped from over 80ms to 20ms, and the median competitive bid increment dropped from 0.47% to 0.09%. With margins and time windows that thin, discarding an already received higher bid for a lower one is a direct, avoidable loss to the proposer.

### Before / after

Example: a relay's bid value across 3 timing games polls is 0.5 ETH, then 1.5 ETH, then 0.5 ETH (last poll regresses, e.g. due to a cancellation).

Before: returns 0.5 ETH, the bid from the last poll by timestamp.
After: returns 1.5 ETH, the highest value seen across all polls.

Also updated docs/timing-games.md to describe the new selection criteria.

## References

https://collective.flashbots.net/t/4734 (margin compression context)
https://collective.flashbots.net/t/491 (unrealized value in mev-boost)

---

## I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
