### PR TITLE
Fix uint64 underflow in getHeader msIntoSlot for requests arriving before slot start

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -62,7 +62,15 @@ func (m *BoostService) getHeader(log *logrus.Entry, slot phase0.Slot, pubkey, pa
 
 	// Log how late into the slot the request starts
 	slotStartTimestamp := m.genesisTime + uint64(slot)*config.SlotTimeSec
-	msIntoSlot := uint64(time.Now().UTC().UnixMilli()) - slotStartTimestamp*1000
+	// The request can arrive before the slot start (e.g. scheduling jitter
+	// between VC and BN), which would underflow the unsigned subtraction and
+	// trip the late-in-slot guard below. Clamp negative values to zero, i.e.
+	// treat an early request as arriving exactly at slot start.
+	msIntoSlotSigned := time.Now().UTC().UnixMilli() - int64(slotStartTimestamp*1000)
+	var msIntoSlot uint64
+	if msIntoSlotSigned > 0 {
+		msIntoSlot = uint64(msIntoSlotSigned)
+	}
 	log.WithFields(logrus.Fields{
 		"genesisTime": m.genesisTime,
 		"slotTimeSec": config.SlotTimeSec,

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -331,10 +331,11 @@ func TestGetHeader(t *testing.T) {
 		header.Set(HeaderAccept, MediaTypeJSON)
 
 		backend := newTestBackend(t, 1, time.Second)
-		// setting genesisTime so slot 1 starts one second in the future,
-		// making msIntoSlot negative. Without clamping, the unsigned
-		// subtraction wraps and the late-in-slot guard skips all relays.
-		backend.boost.genesisTime = uint64(time.Now().Unix()) - 11
+		// setting genesisTime so slot 1 starts several seconds in the future,
+		// making msIntoSlot reliably negative regardless of the Unix()
+		// second-truncation. Without clamping, the unsigned subtraction wraps
+		// and the late-in-slot guard skips all relays.
+		backend.boost.genesisTime = uint64(time.Now().Unix()) - 7
 
 		rr := backend.request(t, http.MethodGet, path, header, nil)
 		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -326,6 +326,21 @@ func TestGetHeader(t *testing.T) {
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
+	t.Run("Request arriving before slot start still queries relays", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set(HeaderAccept, MediaTypeJSON)
+
+		backend := newTestBackend(t, 1, time.Second)
+		// setting genesisTime so slot 1 starts one second in the future,
+		// making msIntoSlot negative. Without clamping, the unsigned
+		// subtraction wraps and the late-in-slot guard skips all relays.
+		backend.boost.genesisTime = uint64(time.Now().Unix()) - 11
+
+		rr := backend.request(t, http.MethodGet, path, header, nil)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
+	})
+
 	t.Run("Okay response from relay deneb", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set(HeaderAccept, MediaTypeJSON)


### PR DESCRIPTION
Closes #902.

`getHeader` computes `msIntoSlot` with unsigned arithmetic. When the CL's request arrives even 1ms before slot start (sub-ms scheduling jitter between VC and BN is enough), the subtraction wraps to ~2^64, the late-in-slot guard concludes the request is hopelessly late, and mev-boost returns 204 without querying any relay — the proposer silently falls back to a locally built block and loses the MEV reward. The wrapped value also corrupts the `mev_boost_millisec_into_slot` metric.

This computes the value with signed arithmetic and clamps negatives to zero, i.e. treats an early request as arriving exactly at slot start with the full time budget — mirroring how mev-boost-relay handled its analogous underflow.

Complements #900, which fixes the sibling underflow in the timing-games delay path but is not reached in this scenario: with a wrapped `msIntoSlot` the late-in-slot guard returns before timing games run.

Adds a regression test: a getHeader request arriving before slot start must still query relays and return the bid.
