### PR TITLE
fix(server): guard uint64 subtractions in timing-games getHeader budget

### DIFF
--- a/server/get_header.go
+++ b/server/get_header.go
@@ -192,17 +192,25 @@ func (m *BoostService) handleTimingGamesGetHeader(
 	relay := relayConfig.RelayEntry
 
 	// wait til target time is configured
-	if relayConfig.TargetFirstRequestMs > 0 {
+	if relayConfig.TargetFirstRequestMs > 0 && msIntoSlot < relayConfig.TargetFirstRequestMs {
+		// Both operands are uint64: only subtract after establishing
+		// msIntoSlot < target, otherwise delayMs wraps to ~2^64 and the
+		// unguarded subtraction below INCREASES the remaining budget by
+		// (msIntoSlot - target), defeating the late-in-slot deadline the
+		// budget was computed against.
 		delayMs := relayConfig.TargetFirstRequestMs - msIntoSlot
-		if delayMs > 0 {
-			log.WithFields(logrus.Fields{
-				"targetMs":   relayConfig.TargetFirstRequestMs,
-				"msIntoSlot": msIntoSlot,
-				"delayMs":    delayMs,
-			}).Debug("waiting to send header request via timing games")
+		log.WithFields(logrus.Fields{
+			"targetMs":   relayConfig.TargetFirstRequestMs,
+			"msIntoSlot": msIntoSlot,
+			"delayMs":    delayMs,
+		}).Debug("waiting to send header request via timing games")
+		if delayMs < timeoutLeftMs {
 			timeoutLeftMs -= delayMs
-			time.Sleep(time.Duration(delayMs) * time.Millisecond)
+		} else {
+			// The target time is already at/past the budget end: nothing left.
+			timeoutLeftMs = 0
 		}
+		time.Sleep(time.Duration(delayMs) * time.Millisecond)
 	}
 
 	if relayConfig.FrequencyGetHeaderMs == 0 {


### PR DESCRIPTION
## Problem

In `handleTimingGamesGetHeader`:

```go
delayMs := relayConfig.TargetFirstRequestMs - msIntoSlot  // both uint64
if delayMs > 0 {
    timeoutLeftMs -= delayMs
    ...
}
```

Both operands are unsigned. Whenever the consensus client calls getHeader **later** than `target_first_request_ms` into the slot — the common case with the repo's own example config (`target_first_request_ms: 200`) — the subtraction wraps to ~2^64. The `delayMs > 0` check then passes on the wrapped value, and `timeoutLeftMs -= delayMs` wraps in the opposite direction, i.e. it **increases** the remaining budget by `(msIntoSlot - target)`.

The budget was deliberately computed as `min(timeoutGetHeaderMs, lateInSlotTimeMs - msIntoSlot)` so header requests stop at the late-in-slot deadline; the wrap silently defeats that bound and lets requests run past it. The symmetric case (target beyond the remaining budget) could zero/pre-expire requests instead.

## Fix

- Only compute/subtract when `msIntoSlot < TargetFirstRequestMs` (the wrap is then impossible).
- Clamp the budget decrement at zero so the budget can never be pushed negative (which would wrap to ~2^64 as well).

## Tests

`go build ./...` and `go test ./server/` pass. The changed block is inside the per-relay timing-games path; no interface changes.

Made with Cursor

Made with [Cursor](https://cursor.com)