### PR TITLE
fix(server): match getPayload SSZ preference by relay URL string

### DIFF
--- a/server/get_payload.go
+++ b/server/get_payload.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"slices"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -180,11 +179,15 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 				requestContentType := parsedProposerContentType
 				requestBytes := signedBlindedBeaconBlockBytes
 
-				// Check if the relay supports SSZ
+				// Check if the relay supports SSZ.
+				// Match by URL string: processBid stores RelayEntry.Copy() which allocates a new *url.URL,
+				// so pointer equality would never match the live relay config entry.
 				relaySupportsSSZ := false
+				relayProvidedBid := false
 				for _, originalBidRelay := range originalBid.relays {
-					if relay.URL == originalBidRelay.URL {
+					if relay.String() == originalBidRelay.String() {
 						relaySupportsSSZ = originalBidRelay.SupportsSSZ
+						relayProvidedBid = true
 						break
 					}
 				}
@@ -201,7 +204,7 @@ func (m *BoostService) innerGetPayload(log *logrus.Entry, signedBlindedBeaconBlo
 						return nil, err
 					}
 					innerLog.WithFields(logrus.Fields{
-						"relayProvidedBid": slices.Contains(originalBid.relays, relay),
+						"relayProvidedBid": relayProvidedBid,
 						"conversionTime":   time.Since(startTime),
 					}).Info("Converted request from SSZ to JSON for relay")
 				}

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1453,6 +1454,36 @@ func TestGetPayload(t *testing.T) {
 		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 
 		require.Equal(t, MediaTypeOctetStream, rr.Header().Get(HeaderContentType))
+	})
+
+	t.Run("SSZ preference survives RelayEntry.Copy used by processBid", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set("Eth-Consensus-Version", "deneb")
+		header.Set("Accept", "application/octet-stream")
+		header.Set("Content-Type", "application/octet-stream")
+
+		backend := newTestBackend(t, 1, time.Second)
+
+		// Simulate processBid: store a Copy() with SupportsSSZ set (new *url.URL pointer).
+		relayCopy := backend.relays[0].RelayEntry.Copy()
+		relayCopy.SupportsSSZ = true
+		bid := bidResp{relays: []types.RelayEntry{relayCopy}}
+		backend.boost.bids[bidKey(payload.Message.Slot, payload.Message.Body.ExecutionPayloadHeader.BlockHash)] = bid
+
+		var sawSSZ atomic.Bool
+		backend.relays[0].OverrideHandleGetPayload(func(w http.ResponseWriter, req *http.Request) {
+			if req.Header.Get(HeaderContentType) == MediaTypeOctetStream {
+				sawSSZ.Store(true)
+			}
+			backend.relays[0].DefaultHandleGetPayload(w, req)
+		})
+
+		payloadBytes, err := payload.MarshalSSZ()
+		require.NoError(t, err)
+		rr := backend.requestBytes(t, http.MethodPost, path, header, payloadBytes)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		require.True(t, sawSSZ.Load(), "winning SSZ relay must receive SSZ after Copy()-based bid cache entry")
+		require.Equal(t, 1, backend.relays[0].GetRequestCount(path))
 	})
 
 	t.Run("A relay which does not provide the bid gets a JSON request", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `processBid` stores `RelayEntry.Copy()` (new `*url.URL`) when recording which relays delivered a bid and whether they spoke SSZ.
- `innerGetPayload` compared `relay.URL == originalBidRelay.URL` by pointer, so the match always failed after a real getHeader → getPayload path.
- Result: `SupportsSSZ` was ignored and SSZ proposer bodies were always converted to JSON for every relay (extra latency on the critical path; breaks SSZ-only relays).
- Fix: compare relays with `RelayEntry.String()` (same identity key used elsewhere). Unit test reproduces the `Copy()` path.

## Test plan
- [x] `go test ./server/ -count=1 -run 'TestGetPayload$/SSZ preference'`
- [x] `go test ./server/ -count=1`
- [x] `go build ./...`


Made with [Cursor](https://cursor.com)