### PR TITLE
Validate and canonicalize mux validator pubkeys

### DIFF
--- a/config/mux_config.go
+++ b/config/mux_config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/flashbots/mev-boost/server/types"
 )
@@ -13,6 +15,10 @@ var (
 	ErrMuxNoRelays              = errors.New("mux entry must have at least one relay")
 	ErrMuxNoPubkeys             = errors.New("mux entry must have at least one validator pubkey")
 	ErrDuplicateValidatorPubkey = errors.New("validator pubkey appears in multiple mux entries")
+	ErrInvalidValidatorPubkey   = errors.New("invalid validator pubkey")
+
+	errMissingHexPrefix  = errors.New("missing 0x prefix")
+	errWrongPubkeyLength = errors.New("wrong length")
 )
 
 type RuntimeMuxConfig struct {
@@ -66,12 +72,50 @@ func ValidateMuxEntries(entries []MuxEntryInput) (MuxMap, error) {
 		}
 
 		for _, pubkey := range entry.ValidatorPubkeys {
-			if existing, ok := muxMap[pubkey]; ok {
-				return nil, fmt.Errorf("%w: %s in mux %q and %q", ErrDuplicateValidatorPubkey, pubkey, existing.ID, entry.ID)
+			// Validate and canonicalize. getHeader looks the validator up by
+			// the pubkey the beacon node puts in the request URL, so a mux
+			// keyed on a malformed or differently-cased string can never
+			// match, and does so silently.
+			canonical, err := canonicalValidatorPubkey(pubkey)
+			if err != nil {
+				return nil, fmt.Errorf("mux %s: %w %q: %w", entry.ID, ErrInvalidValidatorPubkey, pubkey, err)
 			}
-			muxMap[pubkey] = runtimeConfig
+
+			if existing, ok := muxMap[canonical]; ok {
+				return nil, fmt.Errorf("%w: %s in mux %q and %q", ErrDuplicateValidatorPubkey, canonical, existing.ID, entry.ID)
+			}
+			muxMap[canonical] = runtimeConfig
 		}
 	}
 
 	return muxMap, nil
+}
+
+// blsPubkeyLen is the length of a BLS public key in bytes.
+const blsPubkeyLen = 48
+
+// canonicalValidatorPubkey checks that pubkey is a 0x-prefixed, 48-byte hex
+// string and returns it lowercased.
+//
+// This is deliberately a syntactic check rather than a full BLS point
+// decompression: these pubkeys are only ever used as lookup keys against the
+// pubkey in a getHeader URL, which mev-boost does not curve-check either.
+// Validating the encoding catches the mistakes that actually silence a mux --
+// a truncated or mistyped key, a missing 0x prefix, or the wrong case --
+// without rejecting the well-formed placeholder keys used in test and staging
+// configs.
+func canonicalValidatorPubkey(pubkey string) (string, error) {
+	// The prefix is matched case-insensitively for the same reason the body
+	// is: hex does not carry case.
+	if len(pubkey) < 2 || !strings.EqualFold(pubkey[:2], "0x") {
+		return "", errMissingHexPrefix
+	}
+	decoded, err := hex.DecodeString(pubkey[2:])
+	if err != nil {
+		return "", err
+	}
+	if len(decoded) != blsPubkeyLen {
+		return "", fmt.Errorf("%w: got %d bytes, want %d", errWrongPubkeyLength, len(decoded), blsPubkeyLen)
+	}
+	return strings.ToLower(pubkey), nil
 }

--- a/config/mux_config_test.go
+++ b/config/mux_config_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flashbots/mev-boost/server/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPubkeyLower = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+	testRelayURL    = "0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@relay1.example.com"
+)
+
+func testRelayConfigs(t *testing.T) []types.RelayConfig {
+	t.Helper()
+	entry, err := types.NewRelayEntry(testRelayURL)
+	require.NoError(t, err)
+	return []types.RelayConfig{{RelayEntry: entry}}
+}
+
+// A validator pubkey that is not a well-formed BLS pubkey can never match a
+// getHeader request, so accepting it silently leaves the mux permanently
+// inactive. Reject it at startup instead.
+func TestValidateMuxEntriesRejectsMalformedPubkey(t *testing.T) {
+	for _, pubkey := range []string{
+		"0xdeadbeef",           // too short
+		"not-a-pubkey",         // missing 0x prefix
+		"",                     // empty
+		testPubkeyLower + "ff", // too long
+	} {
+		t.Run(pubkey, func(t *testing.T) {
+			_, err := ValidateMuxEntries([]MuxEntryInput{{
+				ID:               "mux",
+				ValidatorPubkeys: []string{pubkey},
+				RelayConfigs:     testRelayConfigs(t),
+			}})
+			require.Error(t, err, "malformed validator pubkey %q was accepted", pubkey)
+		})
+	}
+}
+
+// Hex pubkeys are case-insensitive, and the getHeader path looks the validator
+// up by the pubkey the beacon node put in the URL. Keying the map on the raw
+// config string makes an uppercase entry silently miss.
+func TestValidateMuxEntriesCanonicalizesPubkeys(t *testing.T) {
+	muxMap, err := ValidateMuxEntries([]MuxEntryInput{{
+		ID:               "mux",
+		ValidatorPubkeys: []string{"0x" + strings.ToUpper(testPubkeyLower[2:])},
+		RelayConfigs:     testRelayConfigs(t),
+	}})
+	require.NoError(t, err)
+	require.Contains(t, muxMap, testPubkeyLower,
+		"mux map is not keyed by the canonical lowercase pubkey")
+
+	// An uppercased 0X prefix is hex too.
+	muxMap, err = ValidateMuxEntries([]MuxEntryInput{{
+		ID:               "mux",
+		ValidatorPubkeys: []string{strings.ToUpper(testPubkeyLower)},
+		RelayConfigs:     testRelayConfigs(t),
+	}})
+	require.NoError(t, err)
+	require.Contains(t, muxMap, testPubkeyLower)
+}
+
+// The duplicate check exists to stop one validator being claimed by two muxes.
+// Comparing raw strings lets the same pubkey slip through in a different case.
+func TestValidateMuxEntriesDetectsDuplicateAcrossCase(t *testing.T) {
+	_, err := ValidateMuxEntries([]MuxEntryInput{
+		{
+			ID:               "mux-a",
+			ValidatorPubkeys: []string{testPubkeyLower},
+			RelayConfigs:     testRelayConfigs(t),
+		},
+		{
+			ID:               "mux-b",
+			ValidatorPubkeys: []string{strings.ToUpper(testPubkeyLower)},
+			RelayConfigs:     testRelayConfigs(t),
+		},
+	})
+	require.ErrorIs(t, err, ErrDuplicateValidatorPubkey)
+}

--- a/server/mux_test.go
+++ b/server/mux_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/flashbots/mev-boost/config"
@@ -140,4 +141,38 @@ func TestAllRelayConfigs(t *testing.T) {
 		all := service.AllRelayConfigs()
 		require.Len(t, all, 3)
 	})
+}
+
+// The pubkey in a getHeader URL is supplied by the beacon node and hex is
+// case-insensitive, so the mux lookup must not depend on the case the CL
+// happens to use. Missing the mux is silent: the validator falls back to the
+// default relay set with no error.
+func TestGetConfigForValidatorIsCaseInsensitive(t *testing.T) {
+	muxRelay := newTestRelayConfig("0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@mux.example.com")
+	defaultRelay := newTestRelayConfig("0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@default.example.com")
+
+	pubkey := "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+	muxConfig := &config.RuntimeMuxConfig{
+		ID:                 "lido",
+		RelayConfigs:       []types.RelayConfig{muxRelay},
+		TimeoutGetHeaderMs: 900,
+		LateInSlotTimeMs:   1500,
+	}
+
+	service := &BoostService{
+		relayConfigs:       []types.RelayConfig{defaultRelay},
+		muxMap:             config.MuxMap{pubkey: muxConfig},
+		timeoutGetHeaderMs: 950,
+		lateInSlotTimeMs:   2000,
+		log:                logrus.NewEntry(logrus.New()),
+	}
+
+	for _, requested := range []string{pubkey, strings.ToUpper(pubkey)} {
+		relayConfigs, timeoutMs, lateMs := service.GetConfigForValidator(requested)
+		require.Len(t, relayConfigs, 1)
+		require.Equal(t, "mux.example.com", relayConfigs[0].RelayEntry.URL.Host,
+			"expected the mux relay for pubkey %q, got the default set", requested)
+		require.Equal(t, uint64(900), timeoutMs)
+		require.Equal(t, uint64(1500), lateMs)
+	}
 }

--- a/server/service.go
+++ b/server/service.go
@@ -565,7 +565,12 @@ func (m *BoostService) UpdateConfig(relayConfigs []types.RelayConfig, timeoutGet
 // Otherwise returns the default relay configs and timeouts.
 func (m *BoostService) GetConfigForValidator(pubkey string) ([]types.RelayConfig, uint64, uint64) {
 	if m.muxMap != nil {
-		if mux, ok := m.muxMap[pubkey]; ok {
+		// Mux keys are canonical lowercase pubkeys. The pubkey here comes
+		// straight from the request URL, and hex is case-insensitive, so fold
+		// it rather than trusting the case the beacon node happened to use.
+		// A plain fold keeps this off the getHeader hot path; the config side
+		// has already validated that every key is a well-formed pubkey.
+		if mux, ok := m.muxMap[strings.ToLower(pubkey)]; ok {
 			return mux.RelayConfigs, mux.TimeoutGetHeaderMs, mux.LateInSlotTimeMs
 		}
 	}


### PR DESCRIPTION
The mux map is keyed on the raw `validator_pubkeys` strings from the config file, and `getHeader` looks a validator up with the raw pubkey segment from the request URL:

```go
// server/service.go
pubkey = vars["pubkey"]
...
if mux, ok := m.muxMap[pubkey]; ok {
```

Neither side is validated or normalized, so two operator mistakes silently disable a mux instead of failing:

1. **A malformed pubkey is accepted at startup** — truncated, mistyped, missing the `0x` prefix, or even the empty string. It can never match a request.
2. **A correctly formed pubkey in a different case never matches** — hex is case-insensitive, Go map keys are not.

In both cases mev-boost starts cleanly, reports the mux as loaded, and then quietly serves that validator from the **default relay set**. Nothing logs a warning. For a mux configured to restrict a validator to a specific relay set, that is a silent routing change.

The same raw comparison also defeats the duplicate check that already exists: the same pubkey listed in two muxes in different cases is not caught by `ErrDuplicateValidatorPubkey`, and silently lands in whichever entry is processed last.

Relay pubkeys already go through `utils.HexToPubkey` in `types.NewRelayEntry` — only the mux path skips validation.

## Change

- `ValidateMuxEntries` validates the encoding and stores the lowercased key.
- `GetConfigForValidator` folds the case of the lookup key.

The check is **syntactic** (0x-prefixed, 48 bytes of hex) rather than a BLS point decompression. These strings are only ever lookup keys, and the `getHeader` pubkey is not curve-checked either, so requiring a valid curve point would be stricter than the matching logic — and would reject well-formed placeholder keys, including the one in the existing `TestParseConfigWithMux` fixture. Folding rather than parsing on lookup also keeps this off the `getHeader` hot path.

## Behavior change

This **rejects a mux config that was previously accepted**: a malformed validator pubkey is now a startup error rather than a mux that never fires. That is the point of the change, but it is a visible difference for anyone currently running a typo, so flagging it explicitly. Happy to downgrade it to a warning-and-skip if you would rather not fail closed on startup.

## Test plan

Four new tests, all failing before the change (verified by reverting only `config/mux_config.go` and `server/service.go` and keeping the tests):

| test | failure without the fix |
| --- | --- |
| `TestValidateMuxEntriesRejectsMalformedPubkey` | `malformed validator pubkey "0xdeadbeef" was accepted` (also `""`, `not-a-pubkey`, over-long) |
| `TestValidateMuxEntriesCanonicalizesPubkeys` | `mux map is not keyed by the canonical lowercase pubkey` |
| `TestValidateMuxEntriesDetectsDuplicateAcrossCase` | duplicate not reported |
| `TestGetConfigForValidatorIsCaseInsensitive` | `expected the mux relay ..., got the default set` |

`go test ./...` passes (including the existing `TestParseConfigWithMux`), plus `go test -race` on the changed packages, `go vet`, and `gofmt -d -s`.

---
🤖 Written with [Claude Code](https://claude.com/claude-code). Every result above comes from a local build and test run.