### PR TITLE
fix(server): replace req field in logrus.Fields with discrete fields to fix JSON marshalling error

### DIFF
--- a/server/register_validator.go
+++ b/server/register_validator.go
@@ -48,7 +48,7 @@ func (m *BoostService) registerValidator(log *logrus.Entry, regBytes []byte, hea
 			}
 
 			log.WithFields(logrus.Fields{
-				"method":        req.Method,
+				"httpMethod":    req.Method,
 				"contentLength": req.ContentLength,
 			}).Debug("sending the registerValidator request")
 

--- a/server/register_validator.go
+++ b/server/register_validator.go
@@ -48,7 +48,8 @@ func (m *BoostService) registerValidator(log *logrus.Entry, regBytes []byte, hea
 			}
 
 			log.WithFields(logrus.Fields{
-				"request": req,
+				"method":        req.Method,
+				"contentLength": req.ContentLength,
 			}).Debug("sending the registerValidator request")
 
 			// Send the request

--- a/server/register_validator_test.go
+++ b/server/register_validator_test.go
@@ -294,3 +294,30 @@ func TestHandleRegisterValidator_HeaderPropagation(t *testing.T) {
 		t.Fatal("timed out waiting for header capture")
 	}
 }
+
+// TestHandleRegisterValidator_JSONFormatter verifies that logging under JSONFormatter does not error or panic
+func TestHandleRegisterValidator_JSONFormatter(t *testing.T) {
+	relay := mock.NewRelay(t)
+	defer relay.Server.Close()
+
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetLevel(logrus.DebugLevel)
+
+	m := &BoostService{
+		relayConfigs:     []types.RelayConfig{types.NewRelayConfig(relay.RelayEntry)},
+		httpClientRegVal: *http.DefaultClient,
+		log:              logrus.NewEntry(logger),
+	}
+
+	reqBody := bytes.NewBufferString("[]")
+	req := httptest.NewRequest(http.MethodPost, "https://example.com"+params.PathRegisterValidator, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NotPanics(t, func() {
+		m.handleRegisterValidator(rr, req)
+	})
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+

--- a/server/register_validator_test.go
+++ b/server/register_validator_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -295,12 +296,15 @@ func TestHandleRegisterValidator_HeaderPropagation(t *testing.T) {
 	}
 }
 
-// TestHandleRegisterValidator_JSONFormatter verifies that logging under JSONFormatter does not error or panic
+// TestHandleRegisterValidator_JSONFormatter verifies that log entries are emitted as valid JSON under JSONFormatter,
+// i.e. all logged fields are JSON-marshalable (logrus silently drops entries that fail to marshal)
 func TestHandleRegisterValidator_JSONFormatter(t *testing.T) {
 	relay := mock.NewRelay(t)
 	defer relay.Server.Close()
 
+	logBuf := new(bytes.Buffer)
 	logger := logrus.New()
+	logger.SetOutput(logBuf)
 	logger.SetFormatter(&logrus.JSONFormatter{})
 	logger.SetLevel(logrus.DebugLevel)
 
@@ -315,9 +319,24 @@ func TestHandleRegisterValidator_JSONFormatter(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	rr := httptest.NewRecorder()
-	require.NotPanics(t, func() {
-		m.handleRegisterValidator(rr, req)
-	})
+	m.handleRegisterValidator(rr, req)
+
 	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Every emitted line must be valid JSON, and the debug entry for the relay
+	// request must be present with its discrete fields
+	var logEntry map[string]any
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(logBuf.String()), "\n") {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry), "log line is not valid JSON: %s", line)
+		if entry["msg"] == "sending the registerValidator request" {
+			logEntry = entry
+			found = true
+		}
+	}
+	require.True(t, found, "expected the 'sending the registerValidator request' debug entry to be emitted")
+	require.Equal(t, http.MethodPost, logEntry["httpMethod"])
+	require.InDelta(t, float64(2), logEntry["contentLength"], 0)
 }
 


### PR DESCRIPTION
Fixes #894

### Problem
In `server/register_validator.go`, `log.WithFields` logged `logrus.Fields{"request": req}` where `req` is a `*http.Request` pointer:
```go
log.WithFields(logrus.Fields{
    "request": req,
}).Debug("sending the registerValidator request")
```
When `mev-boost` is configured to log in JSON format (using `logrus.JSONFormatter`), `json.Marshal` fails on `*http.Request` because it contains unexportable / function fields such as `GetBody func() (io.ReadCloser, error)` and channels (`Cancel <-chan struct{}`).

### Solution
Replace `"request": req` with discrete non-function fields (`"method": req.Method`, `"contentLength": req.ContentLength`).

### Testing
- Added `TestHandleRegisterValidator_JSONFormatter` in `server/register_validator_test.go` verifying logging execution under `logrus.JSONFormatter` with `logrus.DebugLevel`.
- Executed `go test -v ./server/...` in `golang:1.26-bookworm` Docker container:
  ```
  --- PASS: TestGetPayloadForks (0.00s)
  PASS
  ok      github.com/flashbots/mev-boost/server  10.507s
  ```
